### PR TITLE
Failed command is now visible in the prompt

### DIFF
--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -54,6 +54,14 @@ function Prompt {
 
     $lastCommandFailed = !$?
 
+    #Start the vanilla posh-git when in a vanilla windows, else: go nuts
+    if(Vanilla-Window) {
+        Write-Host($pwd.ProviderPath) -nonewline
+        Write-VcsStatus
+        $global:LASTEXITCODE = !$lastCommandFailed
+        return "> "
+    }
+
     $drive = (Get-Drive (Get-Location).Path)
 
     switch -wildcard ($drive){
@@ -86,21 +94,13 @@ function Prompt {
     Write-Prompt (Shorten-Path (Get-Location).Path) -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $driveColor
     Write-Prompt " " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $driveColor
 
-    if(Vanilla-Window){ #use the builtin posh-output
-        Write-VcsStatus
-    } else { #get ~fancy~
-        $status = Get-VCSStatus
-        if ($status) {
-            $lastColor = Write-Fancy-Vcs-Branches($status);
-        }
+    $status = Get-VCSStatus
+    if ($status) {
+        $lastColor = Write-Fancy-Vcs-Branches($status);
     }
 
     # Writes the postfix to the prompt
-    if(Vanilla-Window) {
-        Write-Host -Object ">" -n
-    } else {
-        Write-Prompt $sl.FancySpacerSymbol -ForegroundColor $lastColor
-    }
+    Write-Prompt $sl.FancySpacerSymbol -ForegroundColor $lastColor
 
     return " "
 }

--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -21,6 +21,7 @@ $global:AgnosterPromptSettings = New-Object PSObject -Property @{
   PromptBackgroundColor = [ConsoleColor]::DarkBlue
   SessionInfoBackgroundColor = [ConsoleColor]::Green
   CommandFailedForegroundColor = [ConsoleColor]::Red
+  AdminIconForegroundColor = [ConsoleColor]::DarkGreen
 }
 
 <#
@@ -68,7 +69,7 @@ function Prompt {
 
     #check for elevated prompt
     If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-      Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
+      Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.AdminIconForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
     #check the last command state and indicate if failed
@@ -331,7 +332,8 @@ function Agnoster-Colors {
     Preview-Color -text "PromptForegroundColor          " -color $sl.PromptForegroundColor
     Preview-Color -text "PromptBackgroundColor          " -color $sl.PromptBackgroundColor
     Preview-Color -text "SessionInfoBackgroundColor     " -color $sl.SessionInfoBackgroundColor
-    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.CommandFailedForegroundColor 
+    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.CommandFailedForegroundColor
+    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.AdminIconForegroundColor
     Write-Host ""
 }
 

--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -20,6 +20,7 @@ $global:AgnosterPromptSettings = New-Object PSObject -Property @{
   PromptForegroundColor = [ConsoleColor]::Black
   PromptBackgroundColor = [ConsoleColor]::DarkBlue
   SessionInfoBackgroundColor = [ConsoleColor]::Green
+  CommandFailedForegroundColor = [ConsoleColor]::Red
 }
 
 <#
@@ -70,8 +71,9 @@ function Prompt {
       Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
+    #check the last command state and indicate if failed
     If ($lastCommandFailed) {
-      Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
+      Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.CommandFailedForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
     $user = [Environment]::UserName
@@ -329,6 +331,7 @@ function Agnoster-Colors {
     Preview-Color -text "PromptForegroundColor          " -color $sl.PromptForegroundColor
     Preview-Color -text "PromptBackgroundColor          " -color $sl.PromptBackgroundColor
     Preview-Color -text "SessionInfoBackgroundColor     " -color $sl.SessionInfoBackgroundColor
+    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.CommandFailedForegroundColor 
     Write-Host ""
 }
 

--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -49,6 +49,9 @@ function Start-Up{
 Generates the prompt before each line in the console
 #>
 function Prompt {
+
+    $lastCommandFailed = !$?
+
     $drive = (Get-Drive (Get-Location).Path)
 
     switch -wildcard ($drive){
@@ -65,6 +68,10 @@ function Prompt {
     #check for elevated prompt
     If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
       Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
+    }
+
+    If ($lastCommandFailed) {
+      Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
     $user = [Environment]::UserName

--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -20,7 +20,7 @@ $global:AgnosterPromptSettings = New-Object PSObject -Property @{
   PromptForegroundColor = [ConsoleColor]::Black
   PromptBackgroundColor = [ConsoleColor]::DarkBlue
   SessionInfoBackgroundColor = [ConsoleColor]::Green
-  CommandFailedForegroundColor = [ConsoleColor]::Red
+  CommandFailedIconForegroundColor = [ConsoleColor]::Red
   AdminIconForegroundColor = [ConsoleColor]::DarkGreen
 }
 
@@ -77,7 +77,7 @@ function Prompt {
 
     #check the last command state and indicate if failed
     If ($lastCommandFailed) {
-      Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.CommandFailedForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
+      Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.CommandFailedIconForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
     #check for elevated prompt
@@ -326,14 +326,14 @@ function Shorten-Path([string] $path) {
 
 function Agnoster-Colors {
     Write-Host ""
-    Preview-Color -text "GitDefaultColor                " -color $sl.GitDefaultColor
-    Preview-Color -text "GitLocalChangesColor           " -color $sl.GitLocalChangesColor
-    Preview-Color -text "GitNoLocalChangesAndAheadColor " -color $sl.GitNoLocalChangesAndAheadColor
-    Preview-Color -text "PromptForegroundColor          " -color $sl.PromptForegroundColor
-    Preview-Color -text "PromptBackgroundColor          " -color $sl.PromptBackgroundColor
-    Preview-Color -text "SessionInfoBackgroundColor     " -color $sl.SessionInfoBackgroundColor
-    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.CommandFailedForegroundColor
-    Preview-Color -text "CommandFailedForegroundColor   " -color $sl.AdminIconForegroundColor
+    Preview-Color -text "GitDefaultColor                  " -color $sl.GitDefaultColor
+    Preview-Color -text "GitLocalChangesColor             " -color $sl.GitLocalChangesColor
+    Preview-Color -text "GitNoLocalChangesAndAheadColor   " -color $sl.GitNoLocalChangesAndAheadColor
+    Preview-Color -text "PromptForegroundColor            " -color $sl.PromptForegroundColor
+    Preview-Color -text "PromptBackgroundColor            " -color $sl.PromptBackgroundColor
+    Preview-Color -text "SessionInfoBackgroundColor       " -color $sl.SessionInfoBackgroundColor
+    Preview-Color -text "CommandFailedIconForegroundColor " -color $sl.CommandFailedIconForegroundColor
+    Preview-Color -text "AdminIconForegroundColor         " -color $sl.AdminIconForegroundColor
     Write-Host ""
 }
 

--- a/PS-Agnoster.ps1
+++ b/PS-Agnoster.ps1
@@ -67,14 +67,14 @@ function Prompt {
     # PowerLine starts with a space
     Write-Prompt " " -ForegroundColor $sl.PromptForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
 
-    #check for elevated prompt
-    If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-      Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.AdminIconForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
-    }
-
     #check the last command state and indicate if failed
     If ($lastCommandFailed) {
       Write-Prompt "$($sl.FancyXSymbol) " -ForegroundColor $sl.CommandFailedForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
+    }
+
+    #check for elevated prompt
+    If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+      Write-Prompt "$($sl.ElevatedSymbol) " -ForegroundColor $sl.AdminIconForegroundColor -BackgroundColor $sl.SessionInfoBackgroundColor
     }
 
     $user = [Environment]::UserName


### PR DESCRIPTION
Also added the option to set the colors for session icons (admin, failed command)
Proper separation between the vanilla PS windows and ConEmu setup
