### PR TITLE
Subfolders of user's Home Path has wrong prefix

### DIFF
--- a/Themes/Tools.ps1
+++ b/Themes/Tools.ps1
@@ -338,7 +338,7 @@ function Get-ShortPath
         $shortPath =  $result -join $sl.PromptSymbols.PathSeparator
         if ($shortPath)
         {
-            $drive = (Get-Drive -path $dir.path)
+            $drive = (Get-Drive -path $currentDir.FullName)
             return "$drive$($sl.PromptSymbols.PathSeparator)$shortPath"
         } 
         else 


### PR DESCRIPTION
A folder with a path of C:\Users\Foo\Documents shows up as
C:\Documents instead of ~\Documents, which can cause confusion,
especially if there exists another folder with the same name directly
on the C:\ drive.
