### PR TITLE
Force the prompt function

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -32,8 +32,7 @@ function Set-Prompt
 {
     Import-Module $sl.CurrentThemeLocation
 
-    function global:prompt
-    {
+    [ScriptBlock]$Prompt = {
         $lastCommandFailed = $global:error.Count -gt $sl.ErrorCount
         $sl.ErrorCount = $global:error.Count
 
@@ -48,6 +47,8 @@ function Set-Prompt
         Write-Theme -lastCommandFailed $lastCommandFailed
         return ' '
     }
+
+    Set-Item -Path Function:prompt -Value $Prompt -Force
 }
 
 function global:Write-WithPrompt()


### PR DESCRIPTION
Cmder uses their own prompt function. For some reason they've made it readonly, forcing us to override this when setting our prompt. How about them apples.