### PR TITLE
Fix missing export for 'Get-VirtualEnvName' function.

### DIFF
--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -45,7 +45,7 @@ VariablesToExport = @()
 AliasesToExport = '*'
 
 # Functions to export from this module
-FunctionsToExport = @('Show-Colors', 'Show-ThemeColors', 'Set-Theme', 'Get-VCSStatus', 'Get-VcsInfo', 'Get-Drive', 'Get-ShortPath', 'Get-FullPath', 'Set-CursorForRightBlockWrite', 'Save-CursorPosition', 'Pop-CursorPosition', 'Set-CursorUp', 'Test-VirtualEnv')
+FunctionsToExport = @('Show-Colors', 'Show-ThemeColors', 'Set-Theme', 'Get-VCSStatus', 'Get-VcsInfo', 'Get-Drive', 'Get-ShortPath', 'Get-FullPath', 'Set-CursorForRightBlockWrite', 'Save-CursorPosition', 'Pop-CursorPosition', 'Set-CursorUp', 'Test-VirtualEnv', 'Get-VirtualEnvName')
 
 # Private data to pass to the module specified in RootModule. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{


### PR DESCRIPTION
Themes that are using new VirtualEnv functionality are not working because of missing export for the 'Get-VirtualEnvName' function.