### PR TITLE
Added vscode support

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -7,6 +7,10 @@ function Test-IsVanillaWindow {
         # Hyper.is
         return $false
     }
+    elseif ($env:TERM_PROGRAM -eq "vscode") {
+        # Visual Studio Code 
+        return $false
+    }
     else {
         # Powershell
         return $true


### PR DESCRIPTION
VSCode renders themes pretty nicely with the following setting to change terminal fonts to use a Powerline font:

```
"terminal.integrated.fontFamily": "'DejaVu Sans Mono for Powerline'"
```