### PR TITLE
Add option to hide username and domain in certain themes

### DIFF
--- a/Helpers/Prompt.Tests.ps1
+++ b/Helpers/Prompt.Tests.ps1
@@ -111,3 +111,51 @@ Describe "Get-Drive" {
         }
     }
 }
+
+Describe "Test-NotDefaultUser" {
+    Context "With default user set" {
+        BeforeAll { $DefaultUser = 'name' }
+        It "same username gives 'false'" {
+            $user = 'name'
+            Test-NotDefaultUser($user) | Should Be $false
+        }
+        It "different username gives 'false'" {
+            $user = 'differentName'
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+        It "same username and outside VirtualEnv gives 'false'" {
+            Mock Test-VirtualEnv { return $false }            
+            $user = 'name'
+            Test-NotDefaultUser($user) | Should Be $false
+        }
+        It "same username and inside VirtualEnv same default user gives 'true'" {
+            Mock Test-VirtualEnv { return $true }
+            $user = 'name'
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+        It "different username and inside VirtualEnv same default user gives 'true'" {
+            Mock Test-VirtualEnv { return $true }
+            $user = 'differentName'
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+    }
+    Context "With no default user set" {
+        BeforeAll { $DefaultUser = $null }
+        It "no username gives 'true'" {
+            Test-NotDefaultUser | Should Be $true
+        }
+        It "different username gives 'true'" {
+            $user = 'differentName'
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+        It "different username and outside VirtualEnv gives 'true'" {
+            Mock Test-VirtualEnv { return $false }                        
+            $user = 'differentName'
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+        It "no username and inside VirtualEnv gives 'true'" {
+            Mock Test-VirtualEnv { return $true }                        
+            Test-NotDefaultUser($user) | Should Be $true
+        }
+    }
+}

--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -136,6 +136,10 @@ function Get-VirtualEnvName {
     return $virtualEnvName
 }
 
+function Test-NotDefaultUser($user) {
+    return $DefaultUser -eq $null -or $user -ne $DefaultUser -or (Test-VirtualEnv)
+}
+
 function Set-CursorForRightBlockWrite {
     param(
         [int]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Also do not forget the Posh-Git settings itself (enable the stash indication for
 $GitPromptSettings
 ```
 
+Hide your `username@domain` when not in a virtual machine for the Agnoster, Fish, Honukai, Paradox and Sorin themes:
+
+```bash
+$DefaultUser = 'yourUsernameHere'
+```
+
 ## Helper functions
 
 `Set-Theme`:  set a theme from the Themes directory. If no match is found, it will not be changed. Autocomplete is available to list and complete available themes.

--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -25,7 +25,9 @@ function Write-Theme {
 
     $user = [Environment]::UserName
     $computer = $env:computername
-    Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    if (Test-NotDefaultUser($user)) {
+        Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
     
     if (Test-VirtualEnv) {
         Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -38,9 +38,11 @@ function Write-Theme {
     $user = [Environment]::UserName
     $computer = $env:computername
     $path = Get-FullPath -dir $pwd
-    Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
-
-    if (Test-VirtualEnv) {
+    if (Test-NotDefaultUser($user)) {
+        Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+        
+        if (Test-VirtualEnv) {
         Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
         Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
         Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor

--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -12,13 +12,16 @@ function Write-Theme {
     Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.PromptHighlightColor
     # write user
     $user = [Environment]::UserName
-    Write-Prompt -Object " $user" -ForegroundColor $sl.Colors.PromptHighlightColor
-    # write at (devicename)
-    $device = $env:computername
-    Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
-    Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
-    # write in (folder)
-    Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
+    if (Test-NotDefaultUser($user)) {
+        Write-Prompt -Object " $user" -ForegroundColor $sl.Colors.PromptHighlightColor
+        # write at (devicename)
+        $device = $env:computername
+        Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
+        Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
+        # write in for folder
+        Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
+    }
+    # write folder
     $prompt = Get-FullPath -dir $pwd
     Write-Prompt -Object " $prompt " -ForegroundColor $sl.Colors.AdminIconForegroundColor
     # write on (git:branchname status)    

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -24,9 +24,10 @@ function Write-Theme {
     $user = [Environment]::UserName
     $computer = $env:computername
     $path = Get-FullPath -dir $pwd
-    
-    Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
-    
+    if (Test-NotDefaultUser($user)) {
+        Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+        
     if (Test-VirtualEnv) {
         Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
         Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor

--- a/Themes/Sorin.psm1
+++ b/Themes/Sorin.psm1
@@ -19,7 +19,9 @@ function Write-Theme {
     }
 
     $user = [Environment]::UserName
-    Write-Prompt -Object "$user " -ForegroundColor $sl.Colors.PromptForegroundColor
+    if (Test-NotDefaultUser($user)) {
+        Write-Prompt -Object "$user " -ForegroundColor $sl.Colors.PromptForegroundColor
+    }
 
     # Writes the drive portion
     Write-Prompt -Object "$(Get-ShortPath -dir $pwd) " -ForegroundColor $sl.Colors.DriveForegroundColor


### PR DESCRIPTION
#55 

I've added the option to set a $DefaultUser which will then hide the username and domain in the applicable themes. Unless the user is in a VM. This is similar behaviour to oh-my-zsh. I've modified the existing themes to make use of the new checking function.