### PR TITLE
Fix mistake of non-exported function

### DIFF
--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -60,7 +60,8 @@ FunctionsToExport = @('Show-Colors',
                       'Pop-CursorPosition',
                       'Set-CursorUp',
                       'Test-VirtualEnv',
-                      'Get-VirtualEnvName')
+                      'Get-VirtualEnvName',
+                      'Test-NotDefaultUser')
 
 # Private data to pass to the module specified in RootModule. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{


### PR DESCRIPTION
In my last pull request (#56) I made a mistake of not exporting the function. The function not being found means an error is thrown and oh-my-posh isn't loaded at all. This didn't give any problems when developing, but apparently the scope is loaded differently when the module is loaded by powershell or something. Either way, this commit fixes it. Sorry for the inconvenience...