### PR TITLE
export function Test-NotDefaultUser

### DIFF
--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -59,6 +59,7 @@ FunctionsToExport = @('Show-Colors',
                       'Save-CursorPosition',
                       'Pop-CursorPosition',
                       'Set-CursorUp',
+                      'Test-NotDefaultUser',
                       'Test-VirtualEnv',
                       'Get-VirtualEnvName')
 


### PR DESCRIPTION
With function not exported, a failure occurs before writing $user and $computer or $device to the prompt, and subsequent information fails to display correctly in prompt.

added Test-NotDefaultUser to exported functions.

![test-notdefaultuser](https://user-images.githubusercontent.com/1634366/32130331-9803f178-bb64-11e7-822a-79f9a2335983.png)
