### PR TITLE
Fix location of time stamp for Themes/Paradox.psm1

### DIFF
--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -54,7 +54,8 @@ function Write-Theme {
     $timeStamp = Get-Date -UFormat %r
     $timestamp = "[$timeStamp]"
 
-    Set-CursorForRightBlockWrite -textLength $timestamp.Length
+    $timestampStartAt = [System.Text.Encoding]::GetEncoding("UTF-8").GetByteCount($timestamp)
+    Set-CursorForRightBlockWrite -textLength $timestampStartAt
 
     Write-Host $timeStamp -ForegroundColor $sl.Colors.PromptForegroundColor
 


### PR DESCRIPTION
Hello. I found the location of time stamp of theme Paradox would be wrong when using in Japanese environment. 
Because "AM/PM" in Japanese is "午前/午後" which is 2 characters longer.
![default](https://user-images.githubusercontent.com/2211964/34876774-6a41cf08-f7e6-11e7-8127-d287b6648b9f.PNG)
