### PR TITLE
Adjust themes to string building

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -171,7 +171,7 @@ function Set-CursorForRightBlockWrite {
     $rawUI = $Host.UI.RawUI
     $width = $rawUI.BufferSize.Width
     $space = $width - $textLength
-    Write-Host "$escapeChar[$($space)G" -NoNewline
+    return "$escapeChar[$($space)G"
 }
 
 function Reset-CursorPosition {
@@ -180,20 +180,16 @@ function Reset-CursorPosition {
     $host.UI.RawUI.CursorPosition = $postion
 }
 
-function Save-CursorPosition {
-    Write-Host "$escapeChar[s" -NoNewline
-}
-
-function Pop-CursorPosition {
-    Write-Host "$escapeChar[u" -NoNewline
-}
-
 function Set-CursorUp {
     param(
         [int]
         $lines
     )
-    Write-Host "$escapeChar[$($lines)A" -NoNewline
+    return "$escapeChar[$($lines)A"
+}
+
+function Set-Newline {
+    return "$escapeChar[E"
 }
 
 $escapeChar = [char]27

--- a/Themes/Avit.psm1
+++ b/Themes/Avit.psm1
@@ -40,8 +40,9 @@ function Write-Theme {
         $timeStamp = Get-TimeSinceLastCommit
     }
 
-    Set-CursorForRightBlockWrite -textLength $timestamp.Length
-    Write-Host $timeStamp -ForegroundColor $sl.Colors.PromptBackgroundColor
+    $prompt += Set-CursorForRightBlockWrite -textLength $timestamp.Length
+    $prompt += Write-Prompt $timeStamp -ForegroundColor $sl.Colors.PromptBackgroundColor
+    $prompt += Set-Newline
 
     if (Test-VirtualEnv) {
         $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor -ForegroundColor $sl.Colors.VirtualEnvForegroundColor

--- a/Themes/Darkblood.psm1
+++ b/Themes/Darkblood.psm1
@@ -10,34 +10,36 @@ function Write-Theme {
     )
 
     $prompt = Write-Prompt -Object ([char]::ConvertFromUtf32(0x250C)) -ForegroundColor $sl.Colors.PromptSymbolColor
-    Write-Segment -content (Get-UserName) -foregroundColor $sl.Colors.PromptForegroundColor
+    $user = [System.Environment]::UserName
+    $prompt += Write-Segment -content $user -foregroundColor $sl.Colors.PromptForegroundColor
 
-    $prompt = "$($sl.PromptSymbols.SegmentForwardSymbol) "
+    # $prompt += "$($sl.PromptSymbols.SegmentForwardSymbol) "
 
     $status = Get-VCSStatus
     if ($status) {
         $vcsInfo = Get-VcsInfo -status ($status)
         $info = $vcsInfo.VcInfo
-        Write-Segment -content $info -foregroundColor $sl.Colors.GitForegroundColor
+        $prompt += Write-Segment -content $info -foregroundColor $sl.Colors.GitForegroundColor
     }
 
     #check for elevated prompt
     If (Test-Administrator) {
-        Write-Segment -content $sl.PromptSymbols.ElevatedSymbol -foregroundColor $sl.Colors.AdminIconForegroundColor
+        $prompt += Write-Segment -content $sl.PromptSymbols.ElevatedSymbol -foregroundColor $sl.Colors.AdminIconForegroundColor
     }
 
     #check the last command state and indicate if failed
     If ($lastCommandFailed) {
-        Write-Segment -content $sl.PromptSymbols.FailedCommandSymbol -foregroundColor $sl.Colors.CommandFailedIconForegroundColor
+        $prompt += Write-Segment -content $sl.PromptSymbols.FailedCommandSymbol -foregroundColor $sl.Colors.CommandFailedIconForegroundColor
     }
 
-    Write-Host ''
+    $prompt += ''
 
     # SECOND LINE
+    $prompt += Set-Newline
     $prompt += Write-Prompt -Object ([char]::ConvertFromUtf32(0x2514)) -ForegroundColor $sl.Colors.PromptSymbolColor
-    $prompt = Get-FullPath -dir $pwd
+    $path += Get-FullPath -dir $pwd
     $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentBackwardSymbol -ForegroundColor $sl.Colors.PromptSymbolColor
-    $prompt += Write-Prompt -Object $prompt -ForegroundColor $sl.Colors.PromptForegroundColor
+    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor
 
     if (Test-VirtualEnv) {
         $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) $($sl.PromptSymbols.SegmentBackwardSymbol)" -ForegroundColor $sl.Colors.PromptSymbolColor
@@ -64,12 +66,15 @@ function Write-Segment {
     $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentBackwardSymbol -ForegroundColor $sl.Colors.PromptSymbolColor
     $prompt += Write-Prompt -Object $content -ForegroundColor $foregroundColor
     $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.PromptSymbolColor
+    return $prompt
 }
 
 $sl = $global:ThemeSettings #local settings
 $sl.PromptSymbols.PromptIndicator = '>'
 $sl.PromptSymbols.SegmentForwardSymbol = ']'
 $sl.PromptSymbols.SegmentBackwardSymbol = '['
+$sl.PromptSymbols.PathSeparator = '\'
+$sl.PromptSymbols.FailedCommandSymbol = 'x'
 $sl.Colors.PromptForegroundColor = [ConsoleColor]::White
 $sl.Colors.PromptSymbolColor = [ConsoleColor]::DarkRed
 $sl.Colors.PromptHighlightColor = [ConsoleColor]::DarkBlue

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -8,21 +8,18 @@ function Write-Theme {
         $with
     )
 
-    # Create the right block first, set to 1 line up on the right
-    Save-CursorPosition
     $date = Get-Date -UFormat %d-%m-%Y
     $timeStamp = Get-Date -UFormat %R
 
     $leftText = "$($sl.PromptSymbols.SegmentBackwardSymbol) $date $($sl.PromptSymbols.SegmentSeparatorBackwardSymbol) $timeStamp "
-    Set-CursorUp -lines 1
-    Set-CursorForRightBlockWrite -textLength $leftText.Length
+    $prompt += Set-CursorUp -lines 1
+    $prompt += Set-CursorForRightBlockWrite -textLength $leftText.Length
 
-    $prompt = Write-Prompt -Object "$($sl.PromptSymbols.SegmentBackwardSymbol)" -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $sl.Colors.PromptHighlightColor
+    $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentBackwardSymbol)" -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $sl.Colors.PromptHighlightColor
     $prompt += Write-Prompt " $date $($sl.PromptSymbols.SegmentSeparatorBackwardSymbol) $timeStamp " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
 
-    Pop-CursorPosition
-
     # Write the prompt
+    $prompt += Set-Newline
     $prompt += Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
 
     #check the last command state and indicate if failed

--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -22,7 +22,7 @@ function Write-Theme {
         $prompt += Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
     }
     # write folder
-    $prompt = Get-FullPath -dir $pwd
+    $prompt += Get-FullPath -dir $pwd
     $prompt += Write-Prompt -Object " $prompt " -ForegroundColor $sl.Colors.AdminIconForegroundColor
     # write on (git:branchname status)
     $status = Get-VCSStatus
@@ -39,7 +39,7 @@ function Write-Theme {
     }
     # write [time]
     $timeStamp = Get-Date -Format T
-    Write-Host "[$timeStamp]" -ForegroundColor $sl.Colors.PromptForegroundColor
+    $prompt += Write-Prompt "[$timeStamp]" -ForegroundColor $sl.Colors.PromptForegroundColor
     # check for elevated prompt
     If (Test-Administrator) {
         $prompt += Write-Prompt -Object "$($sl.PromptSymbols.ElevatedSymbol) " -ForegroundColor $sl.Colors.AdminIconForegroundColor
@@ -54,6 +54,7 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
     }
 
+    $prompt += Set-Newline
     $prompt += Write-Prompt -Object $sl.PromptSymbols.PromptIndicator -ForegroundColor $foregroundColor
     $prompt += ' '
     $prompt

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -54,9 +54,10 @@ function Write-Theme {
     $timeStamp = Get-Date -UFormat %r
     $timestamp = "[$timeStamp]"
 
-    Set-CursorForRightBlockWrite -textLength $timestamp.Length
+    $prompt += Set-CursorForRightBlockWrite -textLength $timestamp.Length
+    $prompt += Write-Prompt $timeStamp -ForegroundColor $sl.Colors.PromptForegroundColor
 
-    Write-Host $timeStamp -ForegroundColor $sl.Colors.PromptForegroundColor
+    $prompt += Set-Newline
 
     if ($with) {
         $prompt += Write-Prompt -Object "$($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor

--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -56,14 +56,13 @@ FunctionsToExport = @('Show-Colors',
                       'Get-ShortPath',
                       'Get-FullPath',
                       'Set-CursorForRightBlockWrite',
-                      'Save-CursorPosition',
-                      'Pop-CursorPosition',
                       'Set-CursorUp',
                       'Test-VirtualEnv',
                       'Get-VirtualEnvName',
                       'Test-NotDefaultUser',
                       'Test-Administrator',
-                      'Get-ComputerName')
+                      'Get-ComputerName',
+                      'Set-Newline')
 
 # Private data to pass to the module specified in RootModule. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{


### PR DESCRIPTION
This resolves #74. Due to no longer writing to the terminal immediately, the ANSI escape sequences needed to be adjusted and extended with the newline functionality. Before, Write-Host was used which is no longer an option.