### PR TITLE
Added Themes/PowerLine.psm1

### DIFF
--- a/Themes/PowerLine.psm1
+++ b/Themes/PowerLine.psm1
@@ -1,0 +1,75 @@
+#requires -Version 2 -Modules posh-git
+
+function Write-Theme {
+
+    param(
+        [bool]
+        $lastCommandFailed,
+        [string]
+        $with
+    )
+
+    $lastColor = $sl.Colors.PromptBackgroundColor
+
+    $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+
+    #check the last command state and indicate if failed
+    If ($lastCommandFailed) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.FailedCommandSymbol) " -ForegroundColor $sl.Colors.CommandFailedIconForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+
+    #check for elevated prompt
+    If (Test-Administrator) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.ElevatedSymbol) " -ForegroundColor $sl.Colors.AdminIconForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+
+    $user = [System.Environment]::UserName
+    $computer = Get-ComputerName
+    if (Test-NotDefaultUser($user)) {
+        $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+
+    if (Test-VirtualEnv) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    }
+    else {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    }
+
+    # Writes the drive portion
+    $path = (Get-FullPath -dir $pwd).Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    
+    $status = Get-VCSStatus
+    if ($status) {
+        $themeInfo = Get-VcsInfo -status ($status)
+        $lastColor = $themeInfo.BackgroundColor
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
+        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+    }
+
+    if ($with) {
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor -BackgroundColor $sl.Colors.WithBackgroundColor
+        $prompt += Write-Prompt -Object " $($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
+        $lastColor = $sl.Colors.WithBackgroundColor
+    }
+
+    # Writes the postfix to the prompt
+    $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor
+    $prompt += ' '
+    $prompt
+}
+
+$sl = $global:ThemeSettings #local settings
+$sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
+$sl.Colors.SessionInfoBackgroundColor = [ConsoleColor]::DarkGray
+$sl.Colors.PromptForegroundColor = [ConsoleColor]::White
+$sl.Colors.PromptSymbolColor = [ConsoleColor]::White
+$sl.Colors.PromptHighlightColor = [ConsoleColor]::DarkBlue
+$sl.Colors.GitForegroundColor = [ConsoleColor]::DarkGray
+$sl.Colors.WithForegroundColor = [ConsoleColor]::White
+$sl.Colors.WithBackgroundColor = [ConsoleColor]::DarkRed
+$sl.Colors.VirtualEnvBackgroundColor = [System.ConsoleColor]::Red
+$sl.Colors.VirtualEnvForegroundColor = [System.ConsoleColor]::White


### PR DESCRIPTION
I created a new Theme PowerLine, it based Agnoster, Paradox and [powerline](https://github.com/powerline/powerline), It looks like this:

![show-themecolors](https://user-images.githubusercontent.com/232161/37503435-69418d10-2913-11e8-9e30-d07604070bd8.png)
![show-colors](https://user-images.githubusercontent.com/232161/37503436-6adb9206-2913-11e8-9987-05be90084187.png)
![git](https://user-images.githubusercontent.com/232161/37503438-6c643740-2913-11e8-9a9b-9ed14fe7b0c6.png)

The feature of this theme:

1. The prompt and the command line on the same line, just like Agnoster.
2. Showing full path instead of short path, just like Paradox.
3. The background of user@computer changed to DarkGray. On the Windows Console, it looks much better than using Black.
4. Using ![path-separator](https://user-images.githubusercontent.com/232161/37503822-a2138fe2-2915-11e8-9489-5a5bdd4b3692.png) as the path separator, just like powerline.
