### PR TITLE
Changing casing for Computer/Hostname

### DIFF
--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -24,7 +24,8 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = Get-ComputerName
+    $computer = (Get-Culture).TextInfo
+    $computer = $computer.ToTitleCase($env:computername.ToLower())
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -33,7 +33,8 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = $env:computername
+    $computer = (Get-Culture).TextInfo
+    $computer = $computer.ToTitleCase($env:computername.ToLower())
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -15,7 +15,8 @@ function Write-Theme {
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object " $user" -ForegroundColor $sl.Colors.PromptHighlightColor
         # write at (devicename)
-        $device = $env:computername
+        $device = (Get-Culture).TextInfo
+        $device = $device.ToTitleCase($env:computername.ToLower())
         $prompt += Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
         $prompt += Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
         # write in for folder

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -22,7 +22,8 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = $env:computername
+    $computer = (Get-Culture).TextInfo
+    $computer = $computer.ToTitleCase($env:computername.ToLower())
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/Themes/PowerLine.psm1
+++ b/Themes/PowerLine.psm1
@@ -24,7 +24,8 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = Get-ComputerName
+    $computer = (Get-Culture).TextInfo
+    $computer = $computer.ToTitleCase($env:computername.ToLower())
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }


### PR DESCRIPTION
A style choice more than anything, with the current themes the computername/hostname are in all caps which isn't the actual case. 

What this change will do is convert the all caps to "Proper case"

e.g. SUNDOWN will become Sundown.