### PR TITLE
Use "`n" for settings newline instead of ANSI ecape sequence

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -189,7 +189,7 @@ function Set-CursorUp {
 }
 
 function Set-Newline {
-    return "$escapeChar[E"
+    return "`n"
 }
 
 $escapeChar = [char]27


### PR DESCRIPTION
Resolves #82, Resolves #78