### PR TITLE
Unix fixes

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -25,7 +25,7 @@ function Get-Home {
 
 function Test-Administrator {
     if ($PSVersionTable.Platform -eq 'Unix') {
-        return $false #TO-DO: find out how to distinguish this one
+        return (whoami) -eq 'root'
     } elseif ($PSVersionTable.Platform -eq 'Windows') {
         return $false #TO-DO: find out how to distinguish this one
     } else {
@@ -35,7 +35,11 @@ function Test-Administrator {
 
 function Get-ComputerName {
     if (Test-PsCore -and $PSVersionTable.Platform -ne 'Windows') {
-        return $env:NAME
+        if ($env:NAME) {
+            return $env:NAME
+        } else {
+            return (hostname)
+        }
     }
     return $env:COMPUTERNAME
 }

--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -38,7 +38,7 @@ function Get-ComputerName {
         if ($env:NAME) {
             return $env:NAME
         } else {
-            return (hostname)
+            return (uname -n)
         }
     }
     return $env:COMPUTERNAME


### PR DESCRIPTION
Fix admin indicator and computer name for Unix systems.

Adresses #94 and #95.