### PR TITLE
Remove Start-Up

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -6,22 +6,6 @@
 
 <#
         .SYNOPSIS
-        Method called at each launch of Powershell
-
-        .DESCRIPTION
-        Sets up things needed in each console session, aside from prompt
-#>
-function Start-Up {
-    if(Test-Path -Path ~\.last) {
-        (Get-Content -Path ~\.last) | Set-Location
-        Remove-Item -Path ~\.last
-    }
-
-    Set-Prompt
-}
-
-<#
-        .SYNOPSIS
         Generates the prompt before each line in the console
 #>
 function Set-Prompt {
@@ -204,4 +188,3 @@ Register-ArgumentCompleter `
 
 $sl = $global:ThemeSettings #local settings
 $sl.ErrorCount = $global:error.Count
-Start-Up # Executes the Start-Up function, better encapsulation


### PR DESCRIPTION
The Start-Up doesn't really do anything other than set-prompt, and Powershell mores generally state when you import a module, it shouldn't actually do anything until someone asks it to do something. For instance, I want to integrate some of the private functions, but every time I call an import to the module, it sets my prompt. If I want it to set my prompt I'll run Set-Theme or Set-Prompt.