### PR TITLE
Remove PSReadline settings from defaults.ps1

### DIFF
--- a/defaults.ps1
+++ b/defaults.ps1
@@ -73,16 +73,3 @@ $global:PSColor = @{
         Line       = @{ Color = 'White' }
     }
 }
-
-# PSReadline options
-Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
-if ((Get-Module PSReadline).Version.Major -lt 2) {
-    Set-PSReadlineOption -TokenKind Command -ForegroundColor DarkBlue
-    Set-PSReadlineOption -TokenKind Parameter -ForegroundColor Yellow
-}
-else {
-    Set-PSReadlineOption -Colors @{
-        "Command" = [ConsoleColor]::DarkBlue
-        "Parameter" = [ConsoleColor]::Yellow
-    }
-}


### PR DESCRIPTION
Fixes #99 

I found the culprit. The defaults.ps1 sets some PSReadline options, one of which is setting the command text to dark blue.

Default behavior should be to do *nothing*, and only apply things like PSReadline options if the theme dictates it.