### PR TITLE
Set-CursorForRightBlockWrite to use Write-Prompt

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -171,7 +171,7 @@ function Set-CursorForRightBlockWrite {
     $rawUI = $Host.UI.RawUI
     $width = $rawUI.BufferSize.Width
     $space = $width - $textLength
-    return "$escapeChar[$($space)G"
+    Write-Prompt "$escapeChar[$($space)G"
 }
 
 function Reset-CursorPosition {


### PR DESCRIPTION
Previous behaviour in Powershell Core (e.g. in themes Avit or Paradox):
Offset was appearing on the next line instead of offsetting the clock to the right hand side

Fixes #102 