### PR TITLE
Changing default command color to Cyan

### DIFF
--- a/defaults.ps1
+++ b/defaults.ps1
@@ -77,12 +77,12 @@ $global:PSColor = @{
 # PSReadline options
 Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
 if ((Get-Module PSReadline).Version.Major -lt 2) {
-    Set-PSReadlineOption -TokenKind Command -ForegroundColor DarkBlue
+    Set-PSReadlineOption -TokenKind Command -ForegroundColor Cyan
     Set-PSReadlineOption -TokenKind Parameter -ForegroundColor Yellow
 }
 else {
     Set-PSReadlineOption -Colors @{
-        "Command" = [ConsoleColor]::DarkBlue
+        "Command" = [ConsoleColor]::Cyan
         "Parameter" = [ConsoleColor]::Yellow
     }
 }


### PR DESCRIPTION
The default command color in cmder is too difficult to read I think. My theme is set to Monokai.
This also helps if someone tries to open powershell with the default color settings. The DarkBlue is very difficult to read.