### PR TITLE
fix(computername): use Environment::MachineName for computername

### DIFF
--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -24,7 +24,7 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = Get-ComputerName
+    $computer = [System.Environment]::MachineName
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -33,7 +33,7 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = $env:computername
+    $computer = [System.Environment]::MachineName
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -22,7 +22,7 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = $env:computername
+    $computer = [System.Environment]::MachineName
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/Themes/PowerLine.psm1
+++ b/Themes/PowerLine.psm1
@@ -24,7 +24,7 @@ function Write-Theme {
     }
 
     $user = [System.Environment]::UserName
-    $computer = Get-ComputerName
+    $computer = [System.Environment]::MachineName
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }


### PR DESCRIPTION
In the themes, there are inconsistent ways of getting the machine name, some of which do not work properly on PowerShell Core on non-Windows machines.  This PR changes all `$env:computername` and `Get-ComputerName` instances to use `[System.Environment]::MachineName` instead which then will allow the themes to properly display the machine name.