### PR TITLE
Adding SkipPublisherCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install-Module oh-my-posh -Scope CurrentUser
 
 In case you're running this on PS Core, make sure to also install version 2.0.0-beta1 of `PSReadLine`
 
-    Install-Module -Name PSReadLine -AllowPrerelease -Scope CurrentUser -Force
+    Install-Module -Name PSReadLine -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck
 
 To enable the engine edit your PowerShell profile:
 


### PR DESCRIPTION
When I try without "SkipPublisherCheck" i got such an error;

PackageManagement\Install-Package : The version '1.2' of the module 'PSReadLine' being installed is not catalog signed. Ensure that the version '1.2' of the module 'PSReadLine' has the catalog file 'PSReadLine.cat' and signed with the
same publisher 'CN=Microsoft Root Certificate Authority 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US' as the previously-installed module '1.2' with version '2.0.0' under the directory 'C:\Program
Files\WindowsPowerShell\Modules\PSReadline\2.0.0'. If you still want to install or update, use -SkipPublisherCheck parameter.

That is why I add this parameter. 