### PR TITLE
Display time in 24-hour format.

### DIFF
--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -51,7 +51,7 @@ function Write-Theme {
     # Writes the postfix to the prompt
     $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor
 
-    $timeStamp = Get-Date -UFormat %r
+    $timeStamp = Get-Date -UFormat %R
     $timestamp = "[$timeStamp]"
 
     $prompt += Set-CursorForRightBlockWrite -textLength $timestamp.Length


### PR DESCRIPTION
When the current locale prints some CJK characters as AM/PM indicator, there will be a layout error. CMDer cannot correctly recognize the width of these characters, and the right alignment will provide less than adequate width, causing some characters to be pushed to an ugly newline.