### PR TITLE
robbyrussell "PS>" fix

### DIFF
--- a/Themes/robbyrussell.psm1
+++ b/Themes/robbyrussell.psm1
@@ -33,6 +33,9 @@ function Write-Theme {
             $prompt += Write-Prompt -Object (" " + $sl.PromptSymbols.GitDirtyIndicator) -ForegroundColor $sl.Colors.GitDefaultColor
         }
     }
+    
+    $prompt += ' '
+    $prompt
 }
 
 $sl = $global:ThemeSettings #local settings


### PR DESCRIPTION
just a small fix to get rid of the default "PS>" part at the end of the prompt in robbyrussell theme.