### PR TITLE
use built-in helper instead of $env:computername

### DIFF
--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -15,7 +15,7 @@ function Write-Theme {
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object " $user" -ForegroundColor $sl.Colors.PromptHighlightColor
         # write at (devicename)
-        $device = $env:computername
+        $device = Get-ComputerName
         $prompt += Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
         $prompt += Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
         # write in for folder


### PR DESCRIPTION
because $env:computername is not xplat. However, the helper function that's already in this project is xplat 😊

(also added a newline at EOF because it's recommended)