### PR TITLE
fixed Get-ComputerName promt helper to get computername from env

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -35,7 +35,9 @@ function Test-Administrator {
 
 function Get-ComputerName {
     if (Test-PsCore -and $PSVersionTable.Platform -ne 'Windows') {
-        if ($env:NAME) {
+        if ($env:COMPUTERNAME) {
+            return $env:COMPUTERNAME
+        } elseif ($env:NAME) {
             return $env:NAME
         } else {
             return (uname -n)


### PR DESCRIPTION
The $env:NAME did not return any result use $env:COMPUTERNAME to get the name.
If this is not set, fall back to the original implementation.

This bug occured to me when running in the following configuration:
- Win 10
- Powershell 6
- honukai theme