### PR TITLE
Make sure prompt has consistent drive formatting

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -136,7 +136,7 @@ function Get-ShortPath {
         $shortPath =  $result -join $sl.PromptSymbols.PathSeparator
         if ($shortPath) {
             $drive = (Get-Drive -dir $dir)
-            return "$drive$($sl.PromptSymbols.PathSeparator)$shortPath"
+            return "$drive`:$($sl.PromptSymbols.PathSeparator)$shortPath"
         }
         else {
             if ($dir.path -eq (Get-Home)) {


### PR DESCRIPTION
Before the `:` was omitted on paths that are not the root:
* ` C:`
* `C\Windows`
The change makes it look more consistent:
* `C:`
* `C:\Windows`