### PR TITLE
Fix regression issue after #136

### DIFF
--- a/Helpers/Prompt.Tests.ps1
+++ b/Helpers/Prompt.Tests.ps1
@@ -105,7 +105,7 @@ Describe "Get-Drive" {
             Get-Drive $path | Should Be "Test$($ThemeSettings.PromptSymbols.PathSeparator)Hello$($ThemeSettings.PromptSymbols.PathSeparator)"
         }
         It "is in C:" {
-            $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Documents'}
+            $path = @{Drive = @{Name = 'C'}; Path = 'C:\Documents'}
             Get-Drive $path | Should Be 'C:'
         }
         It "is has no drive" {

--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -77,7 +77,7 @@ function Get-Drive {
         else {
             $root = $dir.Drive.Name
             if($root) {
-                return $root
+                return $root + ':'
             }
             else {
                 return $dir.Path.Split(':\')[0] + ':'
@@ -138,7 +138,7 @@ function Get-ShortPath {
         $shortPath =  $result -join $sl.PromptSymbols.PathSeparator
         if ($shortPath) {
             $drive = (Get-Drive -dir $dir)
-            return "$drive`:$($sl.PromptSymbols.PathSeparator)$shortPath"
+            return "$drive$($sl.PromptSymbols.PathSeparator)$shortPath"
         }
         else {
             if ($dir.path -eq (Get-Home)) {


### PR DESCRIPTION
Pre #136 - Post #136
![image](https://user-images.githubusercontent.com/5908498/57021417-6fb4ee00-6c2c-11e9-95d3-aad904fc3dce.png)

This change leaves the `~` home path untouched and suffixing the drive name inside the appropriate part of `Get-Drive`.