### PR TITLE
Makes Path `Home` Symbol Customizable

### DIFF
--- a/Helpers/Prompt.Tests.ps1
+++ b/Helpers/Prompt.Tests.ps1
@@ -13,6 +13,7 @@ $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
         SegmentSeparatorForwardSymbol  = '>'
         SegmentSeparatorBackwardSymbol = '<'
         PathSeparator                  = '\'
+        HomeSymbol                     = '*'
     }
 }
 
@@ -93,12 +94,12 @@ Describe "Get-Drive" {
         It "is in the $HOME folder" {
             Mock Get-Home {return 'C:\Users\Jan'}
             $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan'}
-            Get-Drive $path | Should Be '~'
+            Get-Drive $path | Should Be $ThemeSettings.PromptSymbols.HomeSymbol
         }
         It "is somewhere in the $HOME folder" {
             Mock Get-Home {return 'C:\Users\Jan'}
             $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan\Git\Somewhere'}
-            Get-Drive $path | Should Be '~'
+            Get-Drive $path | Should Be $ThemeSettings.PromptSymbols.HomeSymbol
         }
         It "is in 'Microsoft.PowerShell.Core\FileSystem::\\Test\Hello' with provider X:" {
             $path = @{Drive = @{Name = 'X:'}; Path = 'Microsoft.PowerShell.Core\FileSystem::\\Test\Hello'}
@@ -127,6 +128,41 @@ Describe "Get-Drive" {
         It "running outside of the Filesystem in L:" {
             $path = @{Drive = @{Name = 'L:'}; Path = 'L:\Documents'}
             Get-Drive $path | Should Be 'L:'
+        }
+    }
+}
+
+Describe "Get-FullPath" {
+    Context "Running in the FileSystem" {
+        BeforeAll { Mock Get-Provider { return 'FileSystem'} }
+        It "is in the $HOME folder" {
+            Mock Get-Home {return 'C:\Users\Jan'}
+            $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan'}
+            Get-FullPath $path | Should Be $ThemeSettings.PromptSymbols.HomeSymbol
+        }
+        It "is somewhere in the $HOME folder" {
+            Mock Get-Home {return 'C:\Users\Jan'}
+            $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan\Git\Somewhere'}
+            Get-FullPath $path | Should BeLike "$($ThemeSettings.PromptSymbols.HomeSymbol)*"
+        }
+    }
+}
+
+Describe "Get-ShortPath" {
+    Context "Running in the FileSystem" {
+        BeforeAll { 
+            Mock Get-Provider { return 'FileSystem'} 
+            Mock Get-Home {return 'C:\Users\Jan'}
+        }
+        It "is in the $HOME folder" {
+            $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan'}
+            Mock Get-Item { return $path }
+            Get-ShortPath $path | Should Be $ThemeSettings.PromptSymbols.HomeSymbol
+        }
+        It "is somewhere in the $HOME folder" {
+            Mock Get-Item { return $path }
+            $path = @{Drive = @{Name = 'C:'}; Path = 'C:\Users\Jan\Git\Somewhere'}
+            Get-ShortPath $path | Should BeLike "$($ThemeSettings.PromptSymbols.HomeSymbol)*"
         }
     }
 }

--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -68,7 +68,7 @@ function Get-Drive {
     if($provider -eq 'FileSystem') {
         $homedir = Get-Home
         if($dir.Path.StartsWith($homedir)) {
-            return '~'
+            return $sl.PromptSymbols.HomeSymbol
         }
         elseif($dir.Path.StartsWith('Microsoft.PowerShell.Core')) {
             $parts = $dir.Path.Replace('Microsoft.PowerShell.Core\FileSystem::\\','').Split('\')
@@ -101,21 +101,21 @@ function Test-IsVCSRoot {
 function Get-FullPath {
     param(
         [Parameter(Mandatory = $true)]
-        [System.Management.Automation.PathInfo]
+        [System.Object]
         $dir
     )
 
     if ($dir.path -eq "$($dir.Drive.Name):\") {
         return "$($dir.Drive.Name):"
     }
-    $path = $dir.path.Replace((Get-Home),'~').Replace('\', $sl.PromptSymbols.PathSeparator)
+    $path = $dir.path.Replace((Get-Home),$sl.PromptSymbols.HomeSymbol).Replace('\', $sl.PromptSymbols.PathSeparator)
     return $path
 }
 
 function Get-ShortPath {
     param(
         [Parameter(Mandatory = $true)]
-        [System.Management.Automation.PathInfo]
+        [System.Object]
         $dir
     )
 
@@ -142,7 +142,7 @@ function Get-ShortPath {
         }
         else {
             if ($dir.path -eq (Get-Home)) {
-                return '~'
+                return $sl.PromptSymbols.HomeSymbol
             }
             return "$($dir.Drive.Name):"
         }

--- a/Themes/robbyrussell.psm1
+++ b/Themes/robbyrussell.psm1
@@ -18,7 +18,7 @@ function Write-Theme {
     $prompt += Write-Prompt -Object ($sl.PromptSymbols.PromptIndicator + "  ") -ForegroundColor $promtSymbolColor
 
     # Writes the drive portion
-    $drive = "~"
+    $drive = $sl.PromptSymbols.HomeSymbol
     if ($pwd.Path -ne $HOME) {
         $drive = "$(Split-Path -path $pwd -Leaf)"
     }

--- a/defaults.ps1
+++ b/defaults.ps1
@@ -37,6 +37,7 @@ $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
         SegmentSeparatorBackwardSymbol = [char]::ConvertFromUtf32(0x26A1)
         PathSeparator                  = [System.IO.Path]::DirectorySeparatorChar
         VirtualEnvSymbol               = [char]::ConvertFromUtf32(0xE606)
+        HomeSymbol                     = '~'
     }
     Colors               = @{
         GitDefaultColor                         = [ConsoleColor]::DarkGreen


### PR DESCRIPTION
The makes the tilde (`~`) used in home-relative paths be replaceable by themes.