### PR TITLE
Revise Colors Display

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -103,9 +103,8 @@ function Write-ColorPreview {
 }
 
 function Show-Colors {
-    for($i = 0; $i -lt 16; $i++) {
-        $color = [ConsoleColor]$i
-        Write-Host -Object $color -BackgroundColor $i
+    foreach ($color in [enum]::GetValues([ConsoleColor])) {
+        Write-ColorPreview -text "" -color $color
     }
 }
 

--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -99,7 +99,7 @@ function Write-ColorPreview {
     )
 
     Write-Host -Object $text -NoNewline
-    Write-Host -Object '       ' -BackgroundColor $color
+    Write-Host -Object (" {0,-15}" -f $color ) -BackgroundColor $color
 }
 
 function Show-Colors {


### PR DESCRIPTION
Tweaks the display of the various color helpers:
* `Write-ColorPreview`: Writes the color name along with the swatch to make it easy to determine which color is being displayed.
* `Show-Colors`: Changes the logic to loop through all items in the `ConsoleColor` enum instead of integer values and revises the display to use the `Write-ColorPreview` function.

Resulting displays:
* Show-Colors
![Show-Colors](https://user-images.githubusercontent.com/314097/67307951-539d5580-f4c7-11e9-8ace-2524599afa41.png)
* Show-ThemeColors
![Show-ThemeColors](https://user-images.githubusercontent.com/314097/67307952-539d5580-f4c7-11e9-86ab-40c8ee56a625.png)

