### PR TITLE
Add Support for Different Background Colors for Branch Behind / Ahead and Behind

### DIFF
--- a/Helpers/PoshGit.ps1
+++ b/Helpers/PoshGit.ps1
@@ -58,11 +58,21 @@ function Get-VcsInfo {
         $localChanges = $localChanges -or (($status.Untracked -gt 0) -or ($status.Added -gt 0) -or ($status.Modified -gt 0) -or ($status.Deleted -gt 0) -or ($status.Renamed -gt 0))
         #hg/svn flags
 
+        # There are local changes
         if($localChanges) {
             $branchStatusBackgroundColor = $sl.Colors.GitLocalChangesColor
         }
-        if(-not ($localChanges) -and ($status.AheadBy -gt 0)) {
+        # There are no local changes and the current branch is both ahead and behind
+        elseif(($status.AheadBy -gt 0) -and ($status.BehindBy -gt 0)) {
+            $branchStatusBackgroundColor = $sl.Colors.GitNoLocalChangesAndAheadAndBehindColor
+        }
+        # There are no local changes and the current branch is ahead only
+        elseif ($status.AheadBy -gt 0) {
             $branchStatusBackgroundColor = $sl.Colors.GitNoLocalChangesAndAheadColor
+        }
+        # There are no local changes and the current branch is behind only
+        elseif($status.BehindBy -gt 0) {
+            $branchStatusBackgroundColor = $sl.Colors.GitNoLocalChangesAndBehindColor
         }
 
         $vcInfo = Get-BranchSymbol $status.Upstream

--- a/defaults.ps1
+++ b/defaults.ps1
@@ -38,23 +38,25 @@ $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
         VirtualEnvSymbol                 = [char]::ConvertFromUtf32(0xE606)
     }
     Colors               = @{
-        GitDefaultColor                  = [ConsoleColor]::DarkGreen
-        GitLocalChangesColor             = [ConsoleColor]::DarkYellow
-        GitNoLocalChangesAndAheadColor   = [ConsoleColor]::DarkMagenta
-        PromptForegroundColor            = [ConsoleColor]::White
-        PromptHighlightColor             = [ConsoleColor]::DarkBlue
-        DriveForegroundColor             = [ConsoleColor]::DarkBlue
-        PromptBackgroundColor            = [ConsoleColor]::DarkBlue
-        PromptSymbolColor                = [ConsoleColor]::White
-        SessionInfoBackgroundColor       = [ConsoleColor]::Black
-        SessionInfoForegroundColor       = [ConsoleColor]::White
-        CommandFailedIconForegroundColor = [ConsoleColor]::DarkRed
-        AdminIconForegroundColor         = [ConsoleColor]::DarkYellow
-        WithBackgroundColor              = [ConsoleColor]::DarkRed
-        WithForegroundColor              = [ConsoleColor]::White
-        GitForegroundColor               = [ConsoleColor]::Black
-        VirtualEnvForegroundColor        = [ConsoleColor]::White
-        VirtualEnvBackgroundColor        = [ConsoleColor]::Red
+        GitDefaultColor                         = [ConsoleColor]::DarkGreen
+        GitLocalChangesColor                    = [ConsoleColor]::DarkYellow
+        GitNoLocalChangesAndAheadColor          = [ConsoleColor]::DarkMagenta
+        GitNoLocalChangesAndBehindColor         = [ConsoleColor]::DarkRed
+        GitNoLocalChangesAndAheadAndBehindColor = [ConsoleColor]::DarkRed
+        PromptForegroundColor                   = [ConsoleColor]::White
+        PromptHighlightColor                    = [ConsoleColor]::DarkBlue
+        DriveForegroundColor                    = [ConsoleColor]::DarkBlue
+        PromptBackgroundColor                   = [ConsoleColor]::DarkBlue
+        PromptSymbolColor                       = [ConsoleColor]::White
+        SessionInfoBackgroundColor              = [ConsoleColor]::Black
+        SessionInfoForegroundColor              = [ConsoleColor]::White
+        CommandFailedIconForegroundColor        = [ConsoleColor]::DarkRed
+        AdminIconForegroundColor                = [ConsoleColor]::DarkYellow
+        WithBackgroundColor                     = [ConsoleColor]::DarkRed
+        WithForegroundColor                     = [ConsoleColor]::White
+        GitForegroundColor                      = [ConsoleColor]::Black
+        VirtualEnvForegroundColor               = [ConsoleColor]::White
+        VirtualEnvBackgroundColor               = [ConsoleColor]::Red
     }
 }
 

--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -67,7 +67,7 @@ function Show-ThemeColors {
     #
     ##############################
     Write-Host -Object ''
-    $sl.Colors.Keys | Sort-Object | ForEach-Object { Write-ColorPreview -text ("{0,-35}" -f $_ ) -color $sl.Colors[$_] }
+    $sl.Colors.Keys | Sort-Object | ForEach-Object { Write-ColorPreview -text ("{0,-40}" -f $_ ) -color $sl.Colors[$_] }
     Write-Host -Object ''
 }
 


### PR DESCRIPTION
This should fix issue #167. I set the new default colors to `DarkRed`, but only because I couldn't think of anything better.