### PR TITLE
Fallback to home folder for themes location

### DIFF
--- a/defaults.ps1
+++ b/defaults.ps1
@@ -1,8 +1,16 @@
 # Oh-My-Posh default settings
+function Get-ThemesLocation {
+    $folderName = "PoshThemes"
+    if ($PROFILE) {
+        return (Join-Path (Split-Path -Parent $PROFILE) $folderName)
+    }
+    return "~\${$folderName}"
+}
+
 $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
     CurrentUser          = [System.Environment]::UserName
     CurrentThemeLocation = "$PSScriptRoot\Themes\Agnoster.psm1"
-    MyThemesLocation     = (Join-Path (Split-Path -Parent $PROFILE) "PoshThemes")
+    MyThemesLocation     = Get-ThemesLocation
     ErrorCount           = 0
     GitSymbols           = @{
         BranchSymbol                  = [char]::ConvertFromUtf32(0xE0A0)

--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -62,7 +62,8 @@ FunctionsToExport = @('Show-Colors',
                       'Test-NotDefaultUser',
                       'Test-Administrator',
                       'Get-ComputerName',
-                      'Set-Newline')
+                      'Set-Newline',
+                      'Get-ThemesLocation')
 
 # Private data to pass to the module specified in RootModule. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{


### PR DESCRIPTION
There are machines without the $PROFILE variable. In that case this
code fails as it can't find the location and will crash. Now we Fallback
to the home folder to look for any additional user created themes.

Resolves #168.