### PR TITLE
promptswitching: Add support for switching prompt portions on and off

### DIFF
--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -27,27 +27,39 @@ function Write-Theme {
     $computer = [System.Environment]::MachineName
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+        $lastColor = $sl.Colors.SessionInfoBackgroundColor
     }
 
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-    }
-    else {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    # Write the Python Environment
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        }
+        else {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        }
+        $lastColor = $sl.Colors.VirtualEnvBackgroundColor
     }
 
     # Writes the drive portion
-    $prompt += Write-Prompt -Object (Get-ShortPath -dir $pwd) -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-    $prompt += Write-Prompt -Object ' ' -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $prompt += Write-Prompt -Object (Get-ShortPath -dir $pwd) -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $prompt += Write-Prompt -Object ' ' -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $lastColor = $sl.Colors.PromptBackgroundColor
+    }
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $themeInfo = Get-VcsInfo -status ($status)
-        $lastColor = $themeInfo.BackgroundColor
-        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
-        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+    # Writes the VCS Status
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $themeInfo = Get-VcsInfo -status ($status)
+            $statusColor = $themeInfo.BackgroundColor
+            $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor -BackgroundColor $statusColor
+            $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $statusColor -ForegroundColor $sl.Colors.GitForegroundColor
+            $lastColor = $themeInfo.BackgroundColor
+        }
     }
 
     if ($with) {

--- a/Themes/Avit.psm1
+++ b/Themes/Avit.psm1
@@ -11,15 +11,19 @@ function Write-Theme {
 
     $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.PromptForegroundColor
 
-    $dir = Get-FullPath -dir $pwd
+    if ( $sl.PromptControl.DirPrompt ) {
+        $dir = Get-FullPath -dir $pwd
 
-    $prompt += Write-Prompt -Object $dir -ForegroundColor $sl.Colors.PromptForegroundColor
+        $prompt += Write-Prompt -Object $dir -ForegroundColor $sl.Colors.PromptForegroundColor
+    }
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $vcsInfo = Get-VcsInfo -status ($status)
-        $info = $vcsInfo.VcInfo
-        $prompt += Write-Prompt -Object " $info" -ForegroundColor $vcsInfo.BackgroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $vcsInfo = Get-VcsInfo -status ($status)
+            $info = $vcsInfo.VcInfo
+            $prompt += Write-Prompt -Object " $info" -ForegroundColor $vcsInfo.BackgroundColor
+        }
     }
 
     #check for elevated prompt
@@ -44,8 +48,10 @@ function Write-Theme {
     $prompt += Write-Prompt $timeStamp -ForegroundColor $sl.Colors.PromptBackgroundColor
     $prompt += Set-Newline
 
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+        }
     }
 
     if ($with) {

--- a/Themes/Darkblood.psm1
+++ b/Themes/Darkblood.psm1
@@ -15,11 +15,13 @@ function Write-Theme {
 
     # $prompt += "$($sl.PromptSymbols.SegmentForwardSymbol) "
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $vcsInfo = Get-VcsInfo -status ($status)
-        $info = $vcsInfo.VcInfo
-        $prompt += Write-Segment -content $info -foregroundColor $sl.Colors.GitForegroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $vcsInfo = Get-VcsInfo -status ($status)
+            $info = $vcsInfo.VcInfo
+            $prompt += Write-Segment -content $info -foregroundColor $sl.Colors.GitForegroundColor
+        }
     }
 
     #check for elevated prompt
@@ -37,13 +39,19 @@ function Write-Theme {
     # SECOND LINE
     $prompt += Set-Newline
     $prompt += Write-Prompt -Object ([char]::ConvertFromUtf32(0x2514)) -ForegroundColor $sl.Colors.PromptSymbolColor
-    $path += Get-FullPath -dir $pwd
-    $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentBackwardSymbol -ForegroundColor $sl.Colors.PromptSymbolColor
-    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $path += Get-FullPath -dir $pwd
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentBackwardSymbol -ForegroundColor $sl.Colors.PromptSymbolColor
+        $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptSymbolColor
+    }
 
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) $($sl.PromptSymbols.SegmentBackwardSymbol)" -ForegroundColor $sl.Colors.PromptSymbolColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName)" -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentBackwardSymbol)" -ForegroundColor $sl.Colors.PromptSymbolColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName)" -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol)" -ForegroundColor $sl.Colors.PromptSymbolColor
+        }
     }
 
     if ($with) {
@@ -51,7 +59,7 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$($with.ToUpper())" -ForegroundColor $sl.Colors.WithForegroundColor
     }
 
-    $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol)$($sl.PromptSymbols.PromptIndicator)" -ForegroundColor $sl.Colors.PromptSymbolColor
+    $prompt += Write-Prompt -Object "$($sl.PromptSymbols.PromptIndicator)" -ForegroundColor $sl.Colors.PromptSymbolColor
     $prompt += ' '
     $prompt
 }

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -8,6 +8,8 @@ function Write-Theme {
         $with
     )
 
+    $lastColor = $sl.Colors.SessionInfoBackgroundColor
+
     $date = Get-Date -UFormat %d-%m-%Y
     $timeStamp = Get-Date -UFormat %R
 
@@ -39,23 +41,32 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }
 
+    if ( $sl.PromptControl.PyEnvPrompt ) {
         if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-    }
-    else {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        }
+        else {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        }
+        $lastColor = $sl.Colors.VirtualEnvBackgroundColor
     }
 
     # Writes the drive portion
-    $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $lastColor = $sl.Colors.PromptBackgroundColor
+    }
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $themeInfo = Get-VcsInfo -status ($status)
-        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentSeparatorForwardSymbol -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $themeInfo = Get-VcsInfo -status ($status)
+            $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentSeparatorForwardSymbol -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+            $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+            $lastColor = $sl.Colors.PromptBackgroundColor
+        }
     }
 
     if ($with) {
@@ -64,7 +75,7 @@ function Write-Theme {
     }
 
     # Writes the postfix to the prompt
-    $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptBackgroundColor
+    $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor
     $prompt += ' '
     $prompt
 }

--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -18,28 +18,34 @@ function Write-Theme {
         $device = Get-ComputerName
         $prompt += Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
         $prompt += Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
-        # write in for folder
-        $prompt += Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
     }
     # write folder
-    $dir = Get-FullPath -dir $pwd
-    $prompt += Write-Prompt -Object " $dir " -ForegroundColor $sl.Colors.AdminIconForegroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        # write in for folder
+        $prompt += Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
+        $dir = Get-FullPath -dir $pwd
+        $prompt += Write-Prompt -Object " $dir" -ForegroundColor $sl.Colors.AdminIconForegroundColor
+    }
     # write on (git:branchname status)
-    $status = Get-VCSStatus
-    if ($status) {
-        $sl.GitSymbols.BranchSymbol = ''
-        $themeInfo = Get-VcsInfo -status ($status)
-        $prompt += Write-Prompt -Object 'on git:' -ForegroundColor $sl.Colors.PromptForegroundColor
-        $prompt += Write-Prompt -Object "$($themeInfo.VcInfo) " -ForegroundColor $themeInfo.BackgroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $sl.GitSymbols.BranchSymbol = ''
+            $themeInfo = Get-VcsInfo -status ($status)
+            $prompt += Write-Prompt -Object ' on git:' -ForegroundColor $sl.Colors.PromptForegroundColor
+            $prompt += Write-Prompt -Object "$($themeInfo.VcInfo)" -ForegroundColor $themeInfo.BackgroundColor
+        }
     }
     # write virtualenv
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object 'inside env:' -ForegroundColor $sl.Colors.PromptForegroundColor
-        $prompt += Write-Prompt -Object "$(Get-VirtualEnvName) " -ForegroundColor $themeInfo.VirtualEnvForegroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object ' inside env:' -ForegroundColor $sl.Colors.PromptForegroundColor
+            $prompt += Write-Prompt -Object "$(Get-VirtualEnvName)" -ForegroundColor $themeInfo.VirtualEnvForegroundColor
+        }
     }
     # write [time]
     $timeStamp = Get-Date -Format T
-    $prompt += Write-Prompt "[$timeStamp]" -ForegroundColor $sl.Colors.PromptForegroundColor
+    $prompt += Write-Prompt " [$timeStamp]" -ForegroundColor $sl.Colors.PromptForegroundColor
     # check for elevated prompt
     If (Test-Administrator) {
         $prompt += Write-Prompt -Object "$($sl.PromptSymbols.ElevatedSymbol) " -ForegroundColor $sl.Colors.AdminIconForegroundColor

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -8,7 +8,7 @@ function Write-Theme {
         $with
     )
 
-    $lastColor = $sl.Colors.PromptBackgroundColor
+    $lastColor = $sl.Colors.SessionInfoBackgroundColor
     $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
 
     #check the last command state and indicate if failed
@@ -28,24 +28,33 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }
 
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-    }
-    else {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+            $lastColor = $sl.Colors.VirtualEnvBackgroundColor
+        }
+        else {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        }
     }
 
     # Writes the drive portion
-    $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $lastColor = $sl.Colors.PromptBackgroundColor
+    }
 
+    if ( $sl.PromptControl.GitPrompt ) {
     $status = Get-VCSStatus
-    if ($status) {
-        $themeInfo = Get-VcsInfo -status ($status)
-        $lastColor = $themeInfo.BackgroundColor
-        $prompt += Write-Prompt -Object $($sl.PromptSymbols.SegmentForwardSymbol) -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
-        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+        if ($status) {
+            $themeInfo = Get-VcsInfo -status ($status)
+            $statusColor = $themeInfo.BackgroundColor
+            $prompt += Write-Prompt -Object $($sl.PromptSymbols.SegmentForwardSymbol) -ForegroundColor $lastColor -BackgroundColor $statusColor
+            $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $statusColor -ForegroundColor $sl.Colors.GitForegroundColor
+            $lastColor = $themeInfo.BackgroundColor
+        }
     }
 
     # Writes the postfix to the prompt

--- a/Themes/PowerLine.psm1
+++ b/Themes/PowerLine.psm1
@@ -9,7 +9,7 @@ function Write-Theme {
         $with
     )
 
-    $lastColor = $sl.Colors.PromptBackgroundColor
+    $lastColor = $sl.Colors.SessionInfoBackgroundColor
 
     $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
 
@@ -29,25 +29,34 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }
 
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
-    }
-    else {
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        }
+        else {
+            $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        }
+        $lastColor = $sl.Colors.VirtualEnvBackgroundColor
     }
 
     # Writes the drive portion
-    $path = (Get-FullPath -dir $pwd).Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
-    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $path = (Get-FullPath -dir $pwd).Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+        $lastColor = $sl.Colors.PromptBackgroundColor
+    }
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $themeInfo = Get-VcsInfo -status ($status)
-        $lastColor = $themeInfo.BackgroundColor
-        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
-        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $themeInfo = Get-VcsInfo -status ($status)
+            $statusColor = $themeInfo.BackgroundColor
+            $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor -BackgroundColor $statusColor
+            $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $statusColor -ForegroundColor $sl.Colors.GitForegroundColor
+            $lastColor = $themeInfo.BackgroundColor
+        }
     }
 
     if ($with) {

--- a/Themes/Powerlevel10k-Lean.psm1
+++ b/Themes/Powerlevel10k-Lean.psm1
@@ -17,9 +17,11 @@ function Write-Theme {
     }
 
     # git info
-    If ($vcsStatus = Get-VCSStatus) {
-        $vcsInfo = Get-VcsInfo -status ($vcsStatus)
-        $sVcs = "$($vcsInfo.VcInfo) "
+    if ( $sl.PromptControl.GitPrompt ) {
+        If ($vcsStatus = Get-VCSStatus) {
+            $vcsInfo = Get-VcsInfo -status ($vcsStatus)
+            $sVcs = "$($vcsInfo.VcInfo) "
+        }
     }
 
     # timestamp
@@ -31,8 +33,10 @@ function Write-Theme {
     }
 
     # virtualenv
-    If (Test-VirtualEnv) {
-        $sVenv = " $(Get-VirtualEnvName)"
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        If (Test-VirtualEnv) {
+            $sVenv = " $(Get-VirtualEnvName)"
+        }
     }
 
     # with
@@ -45,15 +49,21 @@ function Write-Theme {
 
     $prompt += Write-Prompt -Object $sFailed -ForegroundColor $sl.Colors.CommandFailedIconForegroundColor
     $prompt += Write-Prompt -Object $sWith   -ForegroundColor $sl.Colors.WithForegroundColor
-    $prompt += Write-Prompt -Object $sVenv   -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        $prompt += Write-Prompt -Object $sVenv   -ForegroundColor $sl.Colors.VirtualEnvForegroundColor
+    }
     $prompt += Write-Prompt -Object $sAdmin  -ForegroundColor $sl.Colors.AdminIconForegroundColor
     $prompt += Write-Prompt -Object $sTime   -ForegroundColor $sl.colors.TimestampForegroundColor
     $prompt += Write-Prompt -Object "`r"
-    $prompt += Write-Prompt -Object $sPath   -ForegroundColor $sl.Colors.DriveForegroundColor
-    $prompt += Write-Prompt -Object $sVcs    -ForegroundColor $vcsInfo.BackgroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $prompt += Write-Prompt -Object $sPath   -ForegroundColor $sl.Colors.DriveForegroundColor
+    }
+    if ( $sl.PromptControl.GitPrompt ) {
+        $prompt += Write-Prompt -Object $sVcs    -ForegroundColor $vcsInfo.BackgroundColor
+    }
 
-    If ($sl.DoubleCommandLine) { 
-        $prompt += Set-Newline 
+    If ($sl.DoubleCommandLine) {
+        $prompt += Set-Newline
     }
 
     # Writes the postfixes to the prompt

--- a/Themes/Sorin.psm1
+++ b/Themes/Sorin.psm1
@@ -24,19 +24,25 @@ function Write-Theme {
     }
 
     # Writes the drive portion
-    $prompt += Write-Prompt -Object "$(Get-ShortPath -dir $pwd) " -ForegroundColor $sl.Colors.DriveForegroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $prompt += Write-Prompt -Object "$(Get-ShortPath -dir $pwd) " -ForegroundColor $sl.Colors.DriveForegroundColor
+    }
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $themeInfo = Get-VcsInfo -status ($status)
-        $prompt += Write-Prompt -Object "git:" -ForegroundColor $sl.Colors.PromptForegroundColor
-        $prompt += Write-Prompt -Object "$($themeInfo.VcInfo) " -ForegroundColor $themeInfo.BackgroundColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $themeInfo = Get-VcsInfo -status ($status)
+            $prompt += Write-Prompt -Object "git:" -ForegroundColor $sl.Colors.PromptForegroundColor
+            $prompt += Write-Prompt -Object "$($themeInfo.VcInfo) " -ForegroundColor $themeInfo.BackgroundColor
+        }
     }
 
     # write virtualenv
-    if (Test-VirtualEnv) {
-        $prompt += Write-Prompt -Object 'env:' -ForegroundColor $sl.Colors.PromptForegroundColor
-        $prompt += Write-Prompt -Object "$(Get-VirtualEnvName) " -ForegroundColor $themeInfo.VirtualEnvForegroundColor
+    if ( $sl.PromptControl.PyEnvPrompt ) {
+        if (Test-VirtualEnv) {
+            $prompt += Write-Prompt -Object 'env:' -ForegroundColor $sl.Colors.PromptForegroundColor
+            $prompt += Write-Prompt -Object "$(Get-VirtualEnvName) " -ForegroundColor $themeInfo.VirtualEnvForegroundColor
+        }
     }
 
     if ($with) {

--- a/Themes/pure.psm1
+++ b/Themes/pure.psm1
@@ -15,25 +15,30 @@ function Write-Theme {
     }
 
     # Writes the drive portion
-    $drive = Get-FullPath -dir $pwd
-    $prompt += Write-Prompt -Object $drive -ForegroundColor $sl.Colors.DriveForegroundColor
+    if ( $sl.PromptControl.DirPrompt ) {
+        $drive = Get-FullPath -dir $pwd
+        $prompt += Write-Prompt -Object $drive -ForegroundColor $sl.Colors.DriveForegroundColor
+        $prompt +=  Write-Prompt -Object ' '
+    }
 
-    $prompt +=  Write-Prompt -Object ' '
-
-    $status = Get-VCSStatus
-    if ($status) {
-        $prompt += Write-Prompt -Object "$($status.Branch)" -ForegroundColor $sl.Colors.WithForegroundColor
-        if ($status.Working.Length -gt 0) {
-            $prompt += Write-Prompt -Object (" " + $sl.PromptSymbols.GitDirtyIndicator) -ForegroundColor $sl.Colors.GitDefaultColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            $prompt += Write-Prompt -Object "$($status.Branch)" -ForegroundColor $sl.Colors.WithForegroundColor
+            if ($status.Working.Length -gt 0) {
+                $prompt += Write-Prompt -Object (" " + $sl.PromptSymbols.GitDirtyIndicator) -ForegroundColor $sl.Colors.GitDefaultColor
+            }
         }
     }
 
     # New line
-    $prompt += Set-Newline
+    if ( $sl.PromptControl.GitPrompt -or $sl.PromptControl.DirPrompt ) {
+        $prompt += Set-Newline
+    }
 
     # Writes the postfixes to the prompt
     $prompt += Write-Prompt -Object ($sl.PromptSymbols.PromptIndicator) -ForegroundColor $promtSymbolColor
-    
+
     $prompt += ' '
     $prompt
 }

--- a/Themes/robbyrussell.psm1
+++ b/Themes/robbyrussell.psm1
@@ -18,22 +18,29 @@ function Write-Theme {
     $prompt += Write-Prompt -Object ($sl.PromptSymbols.PromptIndicator + "  ") -ForegroundColor $promtSymbolColor
 
     # Writes the drive portion
-    $drive = $sl.PromptSymbols.HomeSymbol
-    if ($pwd.Path -ne $HOME) {
-        $drive = "$(Split-Path -path $pwd -Leaf)"
+    if ( $sl.PromptControl.DirPrompt ) {
+        $drive = $sl.PromptSymbols.HomeSymbol
+        if ($pwd.Path -ne $HOME) {
+            $drive = "$(Split-Path -path $pwd -Leaf)"
+        }
+        $prompt += Write-Prompt -Object $drive -ForegroundColor $sl.Colors.DriveForegroundColor
     }
-    $prompt += Write-Prompt -Object $drive -ForegroundColor $sl.Colors.DriveForegroundColor
 
-    $status = Get-VCSStatus
-    if ($status) {
-        $prompt += Write-Prompt -Object " git:(" -ForegroundColor $sl.Colors.PromptHighlightColor
-        $prompt += Write-Prompt -Object "$($status.Branch)" -ForegroundColor $sl.Colors.WithForegroundColor
-        $prompt += Write-Prompt -Object ")" -ForegroundColor $sl.Colors.PromptHighlightColor
-        if ($status.Working.Length -gt 0) {
-            $prompt += Write-Prompt -Object (" " + $sl.PromptSymbols.GitDirtyIndicator) -ForegroundColor $sl.Colors.GitDefaultColor
+    if ( $sl.PromptControl.GitPrompt ) {
+        $status = Get-VCSStatus
+        if ($status) {
+            if ( $sl.PromptControl.DirPrompt ) {
+                $prompt +=  Write-Prompt -Object ' '
+            }
+            $prompt += Write-Prompt -Object "git:(" -ForegroundColor $sl.Colors.PromptHighlightColor
+            $prompt += Write-Prompt -Object "$($status.Branch)" -ForegroundColor $sl.Colors.WithForegroundColor
+            $prompt += Write-Prompt -Object ")" -ForegroundColor $sl.Colors.PromptHighlightColor
+            if ($status.Working.Length -gt 0) {
+                $prompt += Write-Prompt -Object (" " + $sl.PromptSymbols.GitDirtyIndicator) -ForegroundColor $sl.Colors.GitDefaultColor
+            }
         }
     }
-    
+
     $prompt += ' '
     $prompt
 }

--- a/Themes/tehrob.psm1
+++ b/Themes/tehrob.psm1
@@ -12,16 +12,21 @@ function Write-Theme
 	$user = $s1.CurrentUser
 	$prompt = Write-Prompt -Object "$user " -ForegroundColor $s1.Colors.PromptForegroundColor
 	$prompt += Write-Prompt -Object ":: " -ForegroundColor $s1.Colors.AdminIconForegroundColor
-	$prompt += Write-Prompt -Object "$(Get-FullPath -dir $pwd) " -ForegroundColor $s1.Colors.DriveForegroundColor
 
-	$status = Get-VCSStatus
-	if ($status)
-	{
-		$gitbranchpre = [char]::ConvertFromUtf32(0x003c)
-		$gitbranchpost = [char]::ConvertFromUtf32(0x003e)
+	if ( $s1.PromptControl.DirPrompt ) {
+		$prompt += Write-Prompt -Object "$(Get-FullPath -dir $pwd) " -ForegroundColor $s1.Colors.DriveForegroundColor
+	}
 
-		$gitinfo = get-vcsinfo -status $status
-		$prompt += Write-Prompt -Object "$gitbranchpre$($gitinfo.vcinfo)$gitbranchpost " -ForegroundColor $($gitinfo.backgroundcolor)
+	if ( $s1.PromptControl.GitPrompt ) {
+		$status = Get-VCSStatus
+		if ($status)
+		{
+			$gitbranchpre = [char]::ConvertFromUtf32(0x003c)
+			$gitbranchpost = [char]::ConvertFromUtf32(0x003e)
+
+			$gitinfo = get-vcsinfo -status $status
+			$prompt += Write-Prompt -Object "$gitbranchpre$($gitinfo.vcinfo)$gitbranchpost " -ForegroundColor $($gitinfo.backgroundcolor)
+		}
 	}
 
 	$prompt += Write-Prompt -Object $s1.PromptSymbols.PromptIndicator -ForegroundColor $s1.Colors.AdminIconForegroundColor

--- a/defaults.ps1
+++ b/defaults.ps1
@@ -71,6 +71,12 @@ $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
         ConsoleTitle = $true
         OriginSymbols = $false
     }
+    PromptControl = @{
+        KubePrompt  = $true
+        PyEnvPrompt = $true
+        DirPrompt   = $true
+        GitPrompt   = $true
+    }
 }
 
 # PSColor default settings

--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -63,7 +63,8 @@ FunctionsToExport = @('Show-Colors',
                       'Test-Administrator',
                       'Get-ComputerName',
                       'Set-Newline',
-                      'Get-ThemesLocation')
+                      'Get-ThemesLocation',
+                      'Switch-Prompt')
 
 # Private data to pass to the module specified in RootModule. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -39,6 +39,28 @@ function Set-Prompt {
     Set-Item -Path Function:prompt -Value $Prompt -Force
 }
 
+function Switch-Prompt {
+    param (
+        [Parameter(Mandatory=$true,
+                   Position=0)]
+        [ValidateSet('Kube','PyEnv','Dir','Git')]
+        [string]
+        $Prompt
+        ,
+        [Parameter(Mandatory=$false)]
+        [switch]
+        $On
+    )
+
+    switch ( $Prompt )
+    {
+        "Kube"  { $sl.PromptControl.KubePrompt = -not $sl.PromptControl.KubePrompt }
+        "PyEnv" { $sl.PromptControl.PyEnvPrompt = -not $sl.PromptControl.PyEnvPrompt }
+        "Dir"   { $sl.PromptControl.DirPrompt = -not $sl.PromptControl.DirPrompt }
+        "Git"   { $sl.PromptControl.GitPrompt = -not $sl.PromptControl.GitPrompt }
+    }
+}
+
 function global:Write-WithPrompt() {
     param(
         [string]


### PR DESCRIPTION
This may or may not be an interesting feature to you.  

It starts in the defaults.ps1 by adding a "PromptControl" structure, adding a True/False to several prompt sections; DirPrompt, GitPrompt, PyEnvPrompt, and KubePrompt.  The latter is there since adding a Kubernetes context prompt area is coming.  

I had to slightly adjust the flow of some of the themes so each separate component would match up with any other component when they are switched on and off, so there would be no lingering beginning or ending characters.  

The individual components are turned on and off using the Switch-Prompt function:

Switch-Prompt Dir
Switch-Prompt Git
Switch-Prompt PyEnv

I tested each Theme to ensure each prompt section properly turns on and off, however I don't know if Fish works as it is supposed to on my Mac and I don't have a Windows machine at the moment.  The Cursor ends up one line above the end of the prompt.  Perhaps it does something more interesting on a Windows machine.

I'll likely follow up with my Kubernetes prompt section, which after adding for myself personally I found I needed to be able to switch on and off sections that I didn't care about in the moment in order to keep my prompt from consuming my whole screen...

If you like it and need me to do anything to bring it into alignment with what your overall plan is, just say the word.  