### PR TITLE
Add CurrentHostname var in global

### DIFF
--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -24,7 +24,7 @@ function Write-Theme {
     }
 
     $user = $sl.CurrentUser
-    $computer = [System.Environment]::MachineName
+    $computer = $sl.CurrentHostname
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
     }

--- a/Themes/Darkblood.psm1
+++ b/Themes/Darkblood.psm1
@@ -11,7 +11,8 @@ function Write-Theme {
 
     $prompt = Write-Prompt -Object ([char]::ConvertFromUtf32(0x250C)) -ForegroundColor $sl.Colors.PromptSymbolColor
     $user = $sl.CurrentUser
-    $prompt += Write-Segment -content $user -foregroundColor $sl.Colors.PromptForegroundColor
+    $computer = $sl.CurrentHostname
+    $prompt += Write-Segment -content "$user@$computer" -foregroundColor $sl.Colors.PromptForegroundColor
 
     # $prompt += "$($sl.PromptSymbols.SegmentForwardSymbol) "
 

--- a/Themes/Fish.psm1
+++ b/Themes/Fish.psm1
@@ -33,7 +33,7 @@ function Write-Theme {
     }
 
     $user = $sl.CurrentUser
-    $computer = [System.Environment]::MachineName
+    $computer = $sl.CurrentHostname
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/Themes/Honukai.psm1
+++ b/Themes/Honukai.psm1
@@ -15,9 +15,9 @@ function Write-Theme {
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object " $user" -ForegroundColor $sl.Colors.PromptHighlightColor
         # write at (devicename)
-        $device = Get-ComputerName
+        $computer = $sl.CurrentHostname
         $prompt += Write-Prompt -Object " at" -ForegroundColor $sl.Colors.PromptForegroundColor
-        $prompt += Write-Prompt -Object " $device" -ForegroundColor $sl.Colors.GitDefaultColor
+        $prompt += Write-Prompt -Object " $computer" -ForegroundColor $sl.Colors.GitDefaultColor
         # write in for folder
         $prompt += Write-Prompt -Object " in" -ForegroundColor $sl.Colors.PromptForegroundColor
     }

--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -22,7 +22,7 @@ function Write-Theme {
     }
 
     $user = $sl.CurrentUser
-    $computer = [System.Environment]::MachineName
+    $computer = $sl.CurrentHostname
     $path = Get-FullPath -dir $pwd
     if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$user@$computer " -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor

--- a/defaults.ps1
+++ b/defaults.ps1
@@ -9,6 +9,7 @@ function Get-ThemesLocation {
 
 $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
     CurrentUser          = [System.Environment]::UserName
+    CurrentHostname      = [System.Environment]::MachineName
     CurrentThemeLocation = "$PSScriptRoot\Themes\Agnoster.psm1"
     MyThemesLocation     = Get-ThemesLocation
     ErrorCount           = 0


### PR DESCRIPTION
I can see that the theme "Fish" for example uses a variable $computer. So I propose to integrate it into the global variables under the name "CurrentHostname". In order to be reusable in other themes.

If it's interesting?

Thank you