### PR TITLE
fix-venv-name

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -172,7 +172,7 @@ function Get-VirtualEnvName {
         } else {
             $virtualEnvName = $env:VIRTUAL_ENV
         }
-        return $virtualEnvName
+        return $virtualEnvName.Trim('[\/]')
     }
     elseif ($Env:CONDA_PROMPT_MODIFIER) {
         [regex]::Match($Env:CONDA_PROMPT_MODIFIER, "^\((.*)\)").Captures.Groups[1].Value;


### PR DESCRIPTION
my `$env:VIRTUAL_ENV` value is : `D:\git\venv/`, the current version of the cmdlet `Get-VirtualEnvName` returns `venv/`. But it should return `venv`. This PR adds a Trim() to return the correct venv name.