### PR TITLE
Make Paradox path foreground color separately modifiable

### DIFF
--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -38,7 +38,7 @@ function Write-Theme {
     }
 
     # Writes the drive portion
-    $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    $prompt += Write-Prompt -Object "$path " -ForegroundColor $sl.Colors.PathForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
 
     $status = Get-VCSStatus
     if ($status) {
@@ -74,6 +74,7 @@ $sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
 $sl.Colors.PromptForegroundColor = [ConsoleColor]::White
 $sl.Colors.PromptSymbolColor = [ConsoleColor]::White
 $sl.Colors.PromptHighlightColor = [ConsoleColor]::DarkBlue
+$sl.Colors.PathForegroundColor = [ConsoleColor]::White
 $sl.Colors.GitForegroundColor = [ConsoleColor]::Black
 $sl.Colors.WithForegroundColor = [ConsoleColor]::DarkRed
 $sl.Colors.WithBackgroundColor = [ConsoleColor]::Magenta


### PR DESCRIPTION
Currently the path portion uses the `PromptForegroundColor` variable which is also used for `StartSymbol` and the timestamp, however customizing all these colors together doesn't really make sense as the latter two are generally rendered on an empty background while the path is rendered on `PromptBackgroundColor`.

This PR makes the path foreground color separately customizable via a new `PathForegroundColor` variable, keeping the same default value.

As for a concrete motivation, I wanted to make the path foreground black, just like the Git status, but that also made the timestamp invisible. With this change this is no longer a problem.

Thanks for the nice work!