### PR TITLE
Display up to three folder levels in the title

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -26,7 +26,12 @@ function Set-Prompt {
 
         if($sl.Options.ConsoleTitle) {
             $location = Get-Location
-            $folder = (Get-ChildItem | Select-Object -First 1).Parent.BaseName
+            $folder = (Get-ChildItem | Select-Object -First 1).Parent.FullName
+            $folderSplit = $folder -split "$([IO.Path]::DirectorySeparatorChar)", 0, "SimpleMatch"
+            if ($folderSplit -gt 3)
+            {
+                $folder = "$($folderSplit[0])", "...", "$($folderSplit[-2])", "$($folderSplit[-1])" -join "$([IO.Path]::DirectorySeparatorChar)"
+			}
             $prompt += "$([char]27)]2;$($folder)$([char]7)"
             if ($location.Provider.Name -eq "FileSystem") {
                 $prompt += "$([char]27)]9;9;`"$($location.Path)`"$([char]7)"


### PR DESCRIPTION
The title of the window or tab is set to the name of the current folder. When you often have more folders open on your system with the same name, you can not see the difference.

An option would be to show more of the folder names, but not all, since they can get long. I went with three levels deep.

![ohmyposh](https://user-images.githubusercontent.com/11310433/81114245-f24c4980-8f21-11ea-91d4-0f4486e00187.png)
