### PR TITLE
Add switch to not abbreviate home path for themes

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -99,13 +99,25 @@ function Get-FullPath {
     param(
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PathInfo]
-        $dir
+        $dir,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $noHomeAbbreviation
     )
 
     if ($dir.path -eq "$($dir.Drive.Name):\") {
         return "$($dir.Drive.Name):"
     }
-    $path = $dir.path.Replace((Get-Home), $sl.PromptSymbols.HomeSymbol).Replace('\', $sl.PromptSymbols.PathSeparator)
+
+    if ($noHomeAbbreviation.IsPresent) {
+        $path = $dir.path
+    }
+    else {
+        $path = $dir.path.Replace((Get-Home), $sl.PromptSymbols.HomeSymbol)
+    }
+    $path = $path.Replace('\', $sl.PromptSymbols.PathSeparator)
+
     return $path
 }
 


### PR DESCRIPTION
Helper function Get-FullPath has optional switch -noHomeAbbreviation
which enables Themes to display paths in the prompt that are never
abbreviated with the home symbol.