### PR TITLE
display all expected 0-valued Git fields

### DIFF
--- a/Helpers/PoshGit.ps1
+++ b/Helpers/PoshGit.ps1
@@ -141,7 +141,7 @@ function Get-VcsInfo {
             if (!$status.HasIndex) {
                 $vcInfo = $vcInfo +  $sl.GitSymbols.BeforeWorkingSymbol
             }
-            if($showStatusWhenZero -or $status.Working.Added) {
+            if($spg.showStatusWhenZero -or $status.Working.Added) {
                 $vcInfo = $vcInfo +  "$($spg.FileAddedText)$($status.Working.Added.Count) "
             }
             if($spg.ShowStatusWhenZero -or $status.Working.Modified) {


### PR DESCRIPTION
A very minor fix. _showStatusWhenZero_ is not referenced correctly in _PoshGit.ps1_ for unstaged added files. Thus unlike all the other fields this field is not displayed if the number is 0 when _showStatusWhenZero_ is true. 

Before:
![Merknad 2020-05-25 115702](https://user-images.githubusercontent.com/57374889/82802311-f57e8980-9e7e-11ea-8466-c855edbc8d0c.png)

After:
![Merknad 2020-05-25 115642](https://user-images.githubusercontent.com/57374889/82802326-fb746a80-9e7e-11ea-9753-ee0fe49d8241.png)