### PR TITLE
Write the PromptIndicator symbol using the PromptSymbolColor instead of the PromptBackgroundColor

### DIFF
--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -62,7 +62,7 @@ function Write-Theme {
     if ($with) {
         $prompt += Write-Prompt -Object "$($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
     }
-    $prompt += Write-Prompt -Object ($sl.PromptSymbols.PromptIndicator) -ForegroundColor $sl.Colors.PromptBackgroundColor
+    $prompt += Write-Prompt -Object ($sl.PromptSymbols.PromptIndicator) -ForegroundColor $sl.Colors.PromptSymbolColor
     $prompt += ' '
     $prompt
 }


### PR DESCRIPTION
As announced in my issue, I have made the change specified in the title.

Closes #245 