### PR TITLE
Fix the tab title

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -26,12 +26,12 @@ function Set-Prompt {
 
         if($sl.Options.ConsoleTitle) {
             $location = Get-Location
-            $folder = (Get-ChildItem | Select-Object -First 1).Parent.FullName
+            $folder = $location.Path
             $folderSplit = $folder -split "$([IO.Path]::DirectorySeparatorChar)", 0, "SimpleMatch"
-            if ($folderSplit -gt 3)
+            if ($folderSplit.length -gt 3)
             {
                 $folder = "$($folderSplit[0])", "...", "$($folderSplit[-2])", "$($folderSplit[-1])" -join "$([IO.Path]::DirectorySeparatorChar)"
-			}
+            }
             $prompt += "$([char]27)]2;$($folder)$([char]7)"
             if ($location.Provider.Name -eq "FileSystem") {
                 $prompt += "$([char]27)]9;9;`"$($location.Path)`"$([char]7)"


### PR DESCRIPTION
The `(Get-ChildItem | Select-Object -First 1).Parent.FullName` will return null when current directory has not subdirectory.
And, `$folderSplit -gt 3` will always be true if the `$folderSplit` is not null. It makes the title looks like "C:\...\C:\somefolder" if has two folder levels.