### PR TITLE
fix display issue of vcs icon in powershell

### DIFF
--- a/Themes/Paradox.psm1
+++ b/Themes/Paradox.psm1
@@ -45,7 +45,7 @@ function Write-Theme {
         $themeInfo = Get-VcsInfo -status ($status)
         $lastColor = $themeInfo.BackgroundColor
         $prompt += Write-Prompt -Object $($sl.PromptSymbols.SegmentForwardSymbol) -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
-        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.UnicodeSpace)$($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
     }
 
     # Writes the postfix to the prompt
@@ -71,6 +71,7 @@ $sl = $global:ThemeSettings #local settings
 $sl.PromptSymbols.StartSymbol = ''
 $sl.PromptSymbols.PromptIndicator = [char]::ConvertFromUtf32(0x276F)
 $sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
+$sl.PromptSymbols.UnicodeSpace = [char]::ConvertFromUtf32(0x2000)
 $sl.Colors.PromptForegroundColor = [ConsoleColor]::White
 $sl.Colors.PromptSymbolColor = [ConsoleColor]::White
 $sl.Colors.PromptHighlightColor = [ConsoleColor]::DarkBlue


### PR DESCRIPTION
Added an invisible unicode space character in front of the vcs/gihub icon to fix display issue in powershell. The issue belongs to the fact, that the icon is wider than monospace characters in the font should be. Using this character fixes the issue.