### PR TITLE
Fix lambda theme

### DIFF
--- a/Themes/Lambda.psm1
+++ b/Themes/Lambda.psm1
@@ -18,8 +18,9 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$($sl.PromptSymbols.ElevatedSymbol) " -ForegroundColor $sl.Colors.AdminIconForegroundColor
     }
 
+    $user = $sl.CurrentUser
     $lambda = [char]::ConvertFromUtf32(0x000003BB)
-    if (Test-NotDefaultUser($lambda)) {
+    if (Test-NotDefaultUser($user)) {
         $prompt += Write-Prompt -Object "$lambda " -ForegroundColor $sl.Colors.PromptForegroundColor
     }
 
@@ -43,6 +44,7 @@ function Write-Theme {
         $prompt += Write-Prompt -Object "$($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
     }
 
+    $prompt
 }
 
 $sl = $global:ThemeSettings #local settings


### PR DESCRIPTION
Without the fixes in this PR, calling `Set-Theme Lambda` just leaves a completely blank prompt. However, with the fixes, it looks like the following:
![LambdaPrompt](https://user-images.githubusercontent.com/1393236/88549268-133aad00-cfee-11ea-936f-61fd8d00462d.png)
