### PR TITLE
Added new theme

### DIFF
--- a/Themes/PowerlinePlus.psm1
+++ b/Themes/PowerlinePlus.psm1
@@ -1,0 +1,89 @@
+#requires -Version 2 -Modules posh-git
+
+function Write-Theme {
+
+    param(
+        [bool]
+        $lastCommandFailed,
+        [string]
+        $with
+    )
+
+    $lastColor = $sl.Colors.PromptBackgroundColor
+
+    $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+
+    $user = $sl.CurrentUser
+    $computer = [System.Environment]::MachineName
+    if (Test-NotDefaultUser($user)) {
+        $prompt += Write-Prompt -Object "$user@$computer" -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+
+    if (Test-VirtualEnv) {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.VirtualEnvSymbol) $(Get-VirtualEnvName) " -ForegroundColor $sl.Colors.VirtualEnvForegroundColor -BackgroundColor $sl.Colors.VirtualEnvBackgroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.VirtualEnvBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    }
+    else {
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    }
+
+    # Writes the drive portion
+    $path = (Get-ShortPath -dir $pwd).Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.PromptBackgroundColor
+    $status = Get-VCSStatus
+    if ($status) {
+        $themeInfo = Get-VcsInfo -status ($status)
+        $lastColor = $themeInfo.BackgroundColor
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.PromptBackgroundColor -BackgroundColor $lastColor
+        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -BackgroundColor $lastColor -ForegroundColor $sl.Colors.GitForegroundColor
+    }
+
+    if ($with) {
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor -BackgroundColor $sl.Colors.WithBackgroundColor
+        $prompt += Write-Prompt -Object " $($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
+        $lastColor = $sl.Colors.WithBackgroundColor
+    }
+    If ($lastCommandFailed) {
+	$errsign = "!".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $ErrBackground
+	$prompt += Write-Prompt -Object $errsign -ForegroundColor $ErrForeground -BackgroundColor $ErrBackground
+	$lastColor = $ErrBackground
+    }
+
+ If (Test-Administrator) {
+	$rootsign = "#".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $RootBackground
+	$prompt += Write-Prompt -Object $rootsign -ForegroundColor $RootForeground -BackgroundColor $RootBackground
+	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $RootBackground -BackgroundColor $sl.Colors.SessionInfoForegroundColor
+	}
+	else {
+	$norootsign = "$".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+	$prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $ReguserBackground
+	$prompt += Write-Prompt -Object $norootsign -ForegroundColor $ReguserForeground -BackgroundColor $ReguserBackground
+	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $ReguserBackground -BackgroundColor $sl.Colors.SessionInfoForegroundColor
+	}
+
+    # Writes the postfix to the prompt
+    $prompt += ' '
+    $prompt
+}
+
+$sl = $global:ThemeSettings #local settings
+$sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
+$sl.Colors.SessionInfoBackgroundColor = [ConsoleColor]::Cyan
+$sl.Colors.SessionInfoForegroundColor = [ConsoleColor]::Black
+$sl.Colors.PromptForegroundColor = [ConsoleColor]::White
+$sl.Colors.PromptSymbolColor = [ConsoleColor]::White
+$sl.Colors.PromptHighlightColor = [ConsoleColor]::DarkBlue
+$sl.Colors.GitForegroundColor = [ConsoleColor]::Black
+$sl.Colors.WithForegroundColor = [ConsoleColor]::White
+$sl.Colors.WithBackgroundColor = [ConsoleColor]::DarkRed
+$sl.Colors.VirtualEnvBackgroundColor = [System.ConsoleColor]::Red
+$sl.Colors.VirtualEnvForegroundColor = [System.ConsoleColor]::White
+$RootBackground = [ConsoleColor]::Magenta
+$RootForeground = [ConsoleColor]::White
+$ReguserBackground = [ConsoleColor]::Blue
+$ReguserForeground = [ConsoleColor]::White
+$ErrForeground = [ConsoleColor]::White
+$ErrBackground = [ConsoleColor]::DarkRed

--- a/Themes/PowerlinePlus.psm1
+++ b/Themes/PowerlinePlus.psm1
@@ -11,6 +11,23 @@ function Write-Theme {
 
     $lastColor = $sl.Colors.PromptBackgroundColor
 
+# identify background colors for administrative rights
+	# declare the colors
+	$rootBackground = [ConsoleColor]::Magenta
+	$rootForeground = [ConsoleColor]::White
+	$reguserBackground = [ConsoleColor]::Blue
+	$reguserForeground = [ConsoleColor]::White
+
+	# make it work
+	If (Test-Administrator) {
+		$promptTagBackground = $rootBackground
+		$rootForeground = $rootForeground
+		}
+		else {
+		$promptTagBackground = $reguserBackground
+		$promptTagForeground = $reguserForeground
+		}
+
     $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
 
     $user = $sl.CurrentUser
@@ -44,24 +61,29 @@ function Write-Theme {
         $prompt += Write-Prompt -Object " $($with.ToUpper()) " -BackgroundColor $sl.Colors.WithBackgroundColor -ForegroundColor $sl.Colors.WithForegroundColor
         $lastColor = $sl.Colors.WithBackgroundColor
     }
+
     If ($lastCommandFailed) {
-	$errsign = "!".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $ErrBackground
-	$prompt += Write-Prompt -Object $errsign -ForegroundColor $ErrForeground -BackgroundColor $ErrBackground
-	$lastColor = $ErrBackground
-    }
+	$errsign = "ERROR".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $errBackground
+	$prompt += Write-Prompt -Object $errsign -ForegroundColor $errForeground -BackgroundColor $errBackground
+	$lastColor = $errBackground
+	$promptTagBackgroundStatusErrCheck = $errBackground
+    	}
+	else {
+	$promptTagBackgroundStatusErrCheck = $promptTagBackground
+	}
 
  If (Test-Administrator) {
 	$rootsign = "#".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
-        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $RootBackground
-	$prompt += Write-Prompt -Object $rootsign -ForegroundColor $RootForeground -BackgroundColor $RootBackground
-	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $RootBackground -BackgroundColor $sl.Colors.SessionInfoForegroundColor
+        $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $promptTagBackgroundStatusErrCheck
+	$prompt += Write-Prompt -Object $rootsign -ForegroundColor $promptTagForeground -BackgroundColor $promptTagBackgroundStatusErrCheck
+	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $promptTagBackgroundStatusErrCheck -BackgroundColor $sl.Colors.SessionInfoForegroundColor
 	}
 	else {
 	$norootsign = "$".Replace('\', ' ' + [char]::ConvertFromUtf32(0xE0B1) + ' ') + ' '
-	$prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $ReguserBackground
-	$prompt += Write-Prompt -Object $norootsign -ForegroundColor $ReguserForeground -BackgroundColor $ReguserBackground
-	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $ReguserBackground -BackgroundColor $sl.Colors.SessionInfoForegroundColor
+	$prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $lastColor -BackgroundColor $promptTagBackgroundStatusErrCheck
+	$prompt += Write-Prompt -Object $norootsign -ForegroundColor $promptTagForeground -BackgroundColor $promptTagBackgroundStatusErrCheck
+	$prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $promptTagBackgroundStatusErrCheck -BackgroundColor $sl.Colors.SessionInfoForegroundColor
 	}
 
     # Writes the postfix to the prompt
@@ -81,9 +103,5 @@ $sl.Colors.WithForegroundColor = [ConsoleColor]::White
 $sl.Colors.WithBackgroundColor = [ConsoleColor]::DarkRed
 $sl.Colors.VirtualEnvBackgroundColor = [System.ConsoleColor]::Red
 $sl.Colors.VirtualEnvForegroundColor = [System.ConsoleColor]::White
-$RootBackground = [ConsoleColor]::Magenta
-$RootForeground = [ConsoleColor]::White
-$ReguserBackground = [ConsoleColor]::Blue
-$ReguserForeground = [ConsoleColor]::White
-$ErrForeground = [ConsoleColor]::White
-$ErrBackground = [ConsoleColor]::DarkRed
+$errForeground = [ConsoleColor]::White
+$errBackground = [ConsoleColor]::DarkRed


### PR DESCRIPTION
### PowerlinePlus

I'm willing to contribute to oh-my-posh by pushing a new theme, basically the more accurate implementation of Powerline we see on Linux terminals. It also supports distinguishing between Admin and System SID

Keep in mind that this theme is an edit of the already existing "Powerline" theme.

I also provide a GIF preview of the theme:
![powerlineplusdemo1](https://user-images.githubusercontent.com/31619874/89273254-80db7e80-d669-11ea-94c6-177b23176984.gif)
(Demo GIF as of commit 55fee66. Obsolete commit GIFs: [Demo](https://user-images.githubusercontent.com/31619874/89176951-af4b5200-d5b4-11ea-8941-2a22a68795ec.gif) e70e75c, [Demo](https://user-images.githubusercontent.com/31619874/89176751-524f9c00-d5b4-11ea-9fcc-cd327a418bf8.gif) 5cc022f)