### PR TITLE
Fix Left space issue with Agnoster

### DIFF
--- a/Themes/Agnoster.psm1
+++ b/Themes/Agnoster.psm1
@@ -10,8 +10,12 @@ function Write-Theme {
     )
 
     $lastColor = $sl.Colors.PromptBackgroundColor
-
-    $prompt = Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    
+    $prompt=''
+    
+    if($sl.PromptSymbols.StartSymbol -ne ' ') {
+    	$prompt += Write-Prompt -Object $sl.PromptSymbols.StartSymbol -ForegroundColor $sl.Colors.SessionInfoForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
 
     #check the last command state and indicate if failed
     If ($lastCommandFailed) {


### PR DESCRIPTION
By default the `$global:ThemeSettings.PromptSymbols.StartSymbol` is the empty space value. due to this, there is a big space before the username. This PR tries to fix that. 

Before:
![before](https://user-images.githubusercontent.com/7912297/89540626-f044a000-d81a-11ea-8558-44e04b38e586.png)

After:
![after](https://user-images.githubusercontent.com/7912297/89540666-fcc8f880-d81a-11ea-9644-885cf66543f1.png)

With the Custom Start Symbol:
![withIcon](https://user-images.githubusercontent.com/7912297/89540688-03f00680-d81b-11ea-9708-d804ffc21532.png)
