### PR TITLE
Added new theme Powerlevel9k

### DIFF
--- a/Themes/Powerlevel9k.psm1
+++ b/Themes/Powerlevel9k.psm1
@@ -1,0 +1,146 @@
+#requires -Version 2 -Modules posh-git
+
+function Write-Theme {
+    param(
+        [bool]
+        $lastCommandFailed,
+        [string]
+        $with
+    )
+    $adminsymbol = $sl.PromptSymbols.ElevatedSymbol
+    $venvsymbol = $sl.PromptSymbols.VirtualEnvSymbol
+
+    $lastColor = $sl.Colors.SessionInfoBackgroundColor
+    $login = $sl.CurrentUser
+    $computer = (Get-Culture).TextInfo.ToTitleCase([System.Environment]::MachineName.ToLower());
+
+    ## Left Part
+    $prompt = Write-Prompt -Object "╔═" -ForegroundColor $sl.Colors.PromptSymbolColor
+    $prompt += Write-Prompt -Object " $($sl.PromptSymbols.StartSymbol)" -ForegroundColor $sl.Colors.StartForegroundColor
+    $prompt += Write-Prompt -Object " $($sl.PromptSymbols.SegmentSubForwardSymbol)" -ForegroundColor $sl.Colors.UserForegroundColor
+    $prompt += Write-Prompt -Object " $login@$computer " -ForegroundColor $sl.Colors.UserForegroundColor
+    $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.PromptSymbolColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    $pathSymbol = if ($pwd.Path -eq $HOME) { $sl.PromptSymbols.PathHomeSymbol } else { $sl.PromptSymbols.PathSymbol }
+
+    # Writes the drive portion
+    $path = $pathSymbol + " " + (Get-ShortPath -dir $pwd) + " "
+    $prompt += Write-Prompt -Object $path -ForegroundColor $sl.Colors.DriveForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+
+    $status = Get-VCSStatus
+    if ($status) {
+        $themeInfo = Get-VcsInfo -status ($status)
+        $lastColor = $themeInfo.BackgroundColor
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $sl.Colors.SessionInfoBackgroundColor -BackgroundColor $themeInfo.BackgroundColor
+        $prompt += Write-Prompt -Object " $($themeInfo.VcInfo) " -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $themeInfo.BackgroundColor
+    }
+    If ($with) {
+        $sWith = " $($with.ToUpper())"
+        $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentSubForwardSymbol -ForegroundColor $sl.Colors.PromptForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+        $prompt += Write-Prompt -Object $sWith -ForegroundColor $sl.Colors.WithForegroundColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
+    }
+    $prompt += Write-Prompt -Object $sl.PromptSymbols.SegmentForwardSymbol -ForegroundColor $lastColor
+    ###
+
+    ## Right Part
+    $rightElements = New-Object 'System.Collections.Generic.List[Tuple[string,ConsoleColor]]'
+
+    $rightElements.Add([System.Tuple]::Create($sl.PromptSymbols.SegmentBackwardSymbol, $sl.Colors.StatsInfoBackgroundColor))
+    # List of all right elements
+    if (Test-VirtualEnv) {
+        $rightElements.Add([System.Tuple]::Create(" $(Get-VirtualEnvName) $venvsymbol ", $sl.Colors.VirtualEnvForegroundColor))
+        $rightElements.Add([System.Tuple]::Create($sl.PromptSymbols.SegmentSubBackwardSymbol, $sl.Colors.PromptForegroundColor))
+    }
+    if (Test-Administrator) {
+        $rightElements.Add([System.Tuple]::Create(" $adminsymbol", $sl.Colors.AdminIconForegroundColor))
+    }
+
+    # Update battery icon based on status and charge (works only on Windows)
+    if ($env:OS -eq 'Windows_NT') {
+        $charge = (Get-WmiObject win32_battery).EstimatedChargeRemaining
+        if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).Charging) {
+            if ($charge -eq 100) { $batteryhex = 0xf582 }
+            else { $batteryhex = 0xf583 }
+        }
+        else {
+            [int]$level = $charge / 10
+            switch ($level) {
+                0 { $batteryhex = 0xf58d }
+                1 { $batteryhex = 0xf579 }
+                2 { $batteryhex = 0xf57a }
+                3 { $batteryhex = 0xf57b }
+                4 { $batteryhex = 0xf57c }
+                5 { $batteryhex = 0xf57d }
+                6 { $batteryhex = 0xf57e }
+                7 { $batteryhex = 0xf57f }
+                8 { $batteryhex = 0xf580 }
+                9 { $batteryhex = 0xf581 }
+                Default { $batteryhex = 0xf578 }
+            }
+        }
+        $battery = [char]::ConvertFromUtf32($batteryhex)
+        $rightElements.Add([System.Tuple]::Create(" $charge% $battery ", $sl.Colors.PromptForegroundColor))
+        $rightElements.Add([System.Tuple]::Create($sl.PromptSymbols.SegmentSubBackwardSymbol, $sl.Colors.PromptForegroundColor))
+    }
+
+    # Update the clock icon based on time
+    [int]$hour = Get-Date -UFormat %I
+    switch ($hour) {
+        1 { $clockhex = 0xe382 }
+        2 { $clockhex = 0xe383 }
+        3 { $clockhex = 0xe384 }
+        4 { $clockhex = 0xe385 }
+        5 { $clockhex = 0xe386 }
+        6 { $clockhex = 0xe387 }
+        7 { $clockhex = 0xe388 }
+        8 { $clockhex = 0xe389 }
+        9 { $clockhex = 0xe38a }
+        10 { $clockhex = 0xe38b }
+        11 { $clockhex = 0xe38c }
+        Default { $clockhex = 0xe381 }    
+    }
+    $clocksymbol = [char]::ConvertFromUtf32($clockhex)
+    $rightElements.Add([System.Tuple]::Create(" $(Get-Date -Format HH:mm:ss) $clocksymbol ", $sl.Colors.PromptForegroundColor))
+    
+    $lengthList = [Linq.Enumerable]::Select($rightElements, [Func[Tuple[string, ConsoleColor], int]] { $args[0].Item1.Length })
+    $total = [Linq.Enumerable]::Sum($lengthList)
+    # Transform into total length
+    $prompt += Set-CursorForRightBlockWrite -textLength $total
+    # The line head needs special care and is always drawn
+    $prompt += Write-Prompt -Object $rightElements[0].Item1 -ForegroundColor $sl.Colors.StatsInfoBackgroundColor
+    for ($i = 1; $i -lt $rightElements.Count; $i++) {
+        $prompt += Write-Prompt -Object $rightElements[$i].Item1 -ForegroundColor $rightElements[$i].Item2 -BackgroundColor $sl.Colors.StatsInfoBackgroundColor
+    }
+    ###
+
+    $prompt += Write-Prompt -Object "`r"
+    $prompt += Set-Newline
+
+    # Writes the postfixes to the prompt
+    $indicatorColor = If ($lastCommandFailed) { $sl.Colors.CommandFailedIconForegroundColor } Else { $sl.Colors.PromptSymbolColor }
+    $prompt += Write-Prompt -Object "╚═" -ForegroundColor $indicatorColor
+    $prompt += ' '
+    $prompt
+}
+
+$sl = $global:ThemeSettings #local settings
+$sl.PromptSymbols.StartSymbol = [char]::ConvertFromUtf32(0xe70f)
+$sl.PromptSymbols.PromptIndicator = [char]::ConvertFromUtf32(0x276F)
+$sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
+$sl.PromptSymbols.SegmentSubForwardSymbol = [char]::ConvertFromUtf32(0xE0B1)
+$sl.PromptSymbols.SegmentBackwardSymbol = [char]::ConvertFromUtf32(0xE0B2)
+$sl.PromptSymbols.SegmentSubBackwardSymbol = [char]::ConvertFromUtf32(0xE0B3)
+$sl.PromptSymbols.PathHomeSymbol = [char]::ConvertFromUtf32(0xf015)
+$sl.PromptSymbols.PathSymbol = [char]::ConvertFromUtf32(0xf07c)
+$sl.Colors.PromptBackgroundColor = [ConsoleColor]::DarkGray
+$sl.Colors.SessionInfoBackgroundColor = [ConsoleColor]::DarkBlue
+$sl.Colors.StatsInfoBackgroundColor = [ConsoleColor]::Black
+$sl.Colors.VirtualEnvBackgroundColor = [ConsoleColor]::DarkGray
+$sl.Colors.PromptSymbolColor = [ConsoleColor]::Blue
+$sl.Colors.CommandFailedIconForegroundColor = [ConsoleColor]::DarkRed
+$sl.Colors.DriveForegroundColor = [ConsoleColor]::Cyan
+$sl.Colors.PromptForegroundColor = [ConsoleColor]::White
+$sl.Colors.SessionInfoForegroundColor = [ConsoleColor]::White
+$sl.Colors.StartForegroundColor = [ConsoleColor]::Blue
+$sl.Colors.WithForegroundColor = [ConsoleColor]::Red
+$sl.Colors.VirtualEnvForegroundColor = [ConsoleColor]::Magenta
+$sl.Colors.UserForegroundColor = [ConsoleColor]::White

--- a/Themes/Powerlevel9k.psm1
+++ b/Themes/Powerlevel9k.psm1
@@ -57,9 +57,9 @@ function Write-Theme {
     # Update battery icon based on status and charge (works only on Windows)
     if ($env:OS -eq 'Windows_NT') {
         $charge = (Get-WmiObject win32_battery).EstimatedChargeRemaining
-        if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).Charging) {
-            if ($charge -eq 100) { $batteryhex = 0xf582 }
-            else { $batteryhex = 0xf583 }
+        if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).PowerOnline) {
+            if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).Charging) { $batteryhex = 0xf583 }
+            else { $batteryhex = 0xf582 }
         }
         else {
             [int]$level = $charge / 10


### PR DESCRIPTION
This adds a new theme to Oh-My-Posh - Powerlevel9k. 

Powerlevel9k was the predecessor to Powerlevel10k and some people still like the placement and usage of some information and icons in it. This file is modified version of `Powerlevel10k-Classic.psm1` to make it look like Powerlevel9k. 

The changes include: 
- Added battery status besides the time (only for Windows)
- The battery icon updates in real time! Level indicator, charging indicator, critically low indicator and charge full indicator are shown accordingly 
- The clock icon also updates in real time, based on hour! 
- Changed some icons and placement of computer info 
- Truncated long pathnames for directories
- Changed a few colors to improve readability 

*Screenshots -*

![Screenshot (27)](https://user-images.githubusercontent.com/46838874/90983672-78ea6c80-e58d-11ea-85d7-b84819e019fc.png)

![Screenshot (29)](https://user-images.githubusercontent.com/46838874/90983673-7ab43000-e58d-11ea-9726-c46945e8e4e9.png)
