### PR TITLE
Add Battery info helper function

### DIFF
--- a/Themes/Powerlevel9k.psm1
+++ b/Themes/Powerlevel9k.psm1
@@ -54,8 +54,8 @@ function Write-Theme {
         $rightElements.Add([System.Tuple]::Create(" $adminsymbol", $sl.Colors.AdminIconForegroundColor))
     }
 
-    if (Get-BatteryInfo) {
-        $battery = Get-BatteryInfo
+    $battery = Get-BatteryInfo
+    if ($battery) {
         $rightElements.Add([System.Tuple]::Create(" $battery ", $sl.Colors.PromptForegroundColor))
         $rightElements.Add([System.Tuple]::Create($sl.PromptSymbols.SegmentSubBackwardSymbol, $sl.Colors.PromptForegroundColor))
     }

--- a/Themes/Powerlevel9k.psm1
+++ b/Themes/Powerlevel9k.psm1
@@ -54,31 +54,9 @@ function Write-Theme {
         $rightElements.Add([System.Tuple]::Create(" $adminsymbol", $sl.Colors.AdminIconForegroundColor))
     }
 
-    # Update battery icon based on status and charge (works only on Windows)
-    if ($env:OS -eq 'Windows_NT') {
-        $charge = (Get-WmiObject win32_battery).EstimatedChargeRemaining
-        if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).PowerOnline) {
-            if ((Get-WmiObject -Class batterystatus -Namespace root\wmi).Charging) { $batteryhex = 0xf583 }
-            else { $batteryhex = 0xf582 }
-        }
-        else {
-            [int]$level = $charge / 10
-            switch ($level) {
-                0 { $batteryhex = 0xf58d }
-                1 { $batteryhex = 0xf579 }
-                2 { $batteryhex = 0xf57a }
-                3 { $batteryhex = 0xf57b }
-                4 { $batteryhex = 0xf57c }
-                5 { $batteryhex = 0xf57d }
-                6 { $batteryhex = 0xf57e }
-                7 { $batteryhex = 0xf57f }
-                8 { $batteryhex = 0xf580 }
-                9 { $batteryhex = 0xf581 }
-                Default { $batteryhex = 0xf578 }
-            }
-        }
-        $battery = [char]::ConvertFromUtf32($batteryhex)
-        $rightElements.Add([System.Tuple]::Create(" $charge% $battery ", $sl.Colors.PromptForegroundColor))
+    if (Get-BatteryInfo) {
+        $battery = Get-BatteryInfo
+        $rightElements.Add([System.Tuple]::Create(" $battery ", $sl.Colors.PromptForegroundColor))
         $rightElements.Add([System.Tuple]::Create($sl.PromptSymbols.SegmentSubBackwardSymbol, $sl.Colors.PromptForegroundColor))
     }
 

--- a/Themes/Powerlevel9k.psm1
+++ b/Themes/Powerlevel9k.psm1
@@ -13,10 +13,13 @@ function Write-Theme {
     $lastColor = $sl.Colors.SessionInfoBackgroundColor
     $login = $sl.CurrentUser
     $computer = (Get-Culture).TextInfo.ToTitleCase([System.Environment]::MachineName.ToLower());
+    if ($IsLinux) { $iconhex = 0xf17c }
+    elseif ($IsMacOS) { $iconhex = 0xf302 }
+    else { $iconhex = 0xe70f }
 
     ## Left Part
     $prompt = Write-Prompt -Object "╔═" -ForegroundColor $sl.Colors.PromptSymbolColor
-    $prompt += Write-Prompt -Object " $($sl.PromptSymbols.StartSymbol)" -ForegroundColor $sl.Colors.StartForegroundColor
+    $prompt += Write-Prompt -Object " $([char]::ConvertFromUtf32($iconhex))" -ForegroundColor $sl.Colors.StartForegroundColor
     $prompt += Write-Prompt -Object " $($sl.PromptSymbols.SegmentSubForwardSymbol)" -ForegroundColor $sl.Colors.UserForegroundColor
     $prompt += Write-Prompt -Object " $login@$computer " -ForegroundColor $sl.Colors.UserForegroundColor
     $prompt += Write-Prompt -Object "$($sl.PromptSymbols.SegmentForwardSymbol) " -ForegroundColor $sl.Colors.PromptSymbolColor -BackgroundColor $sl.Colors.SessionInfoBackgroundColor
@@ -74,11 +77,11 @@ function Write-Theme {
         9 { $clockhex = 0xe38a }
         10 { $clockhex = 0xe38b }
         11 { $clockhex = 0xe38c }
-        Default { $clockhex = 0xe381 }    
+        Default { $clockhex = 0xe381 }
     }
     $clocksymbol = [char]::ConvertFromUtf32($clockhex)
     $rightElements.Add([System.Tuple]::Create(" $(Get-Date -Format HH:mm:ss) $clocksymbol ", $sl.Colors.PromptForegroundColor))
-    
+
     $lengthList = [Linq.Enumerable]::Select($rightElements, [Func[Tuple[string, ConsoleColor], int]] { $args[0].Item1.Length })
     $total = [Linq.Enumerable]::Sum($lengthList)
     # Transform into total length
@@ -101,7 +104,6 @@ function Write-Theme {
 }
 
 $sl = $global:ThemeSettings #local settings
-$sl.PromptSymbols.StartSymbol = [char]::ConvertFromUtf32(0xe70f)
 $sl.PromptSymbols.PromptIndicator = [char]::ConvertFromUtf32(0x276F)
 $sl.PromptSymbols.SegmentForwardSymbol = [char]::ConvertFromUtf32(0xE0B0)
 $sl.PromptSymbols.SegmentSubForwardSymbol = [char]::ConvertFromUtf32(0xE0B1)

--- a/oh-my-posh.psd1
+++ b/oh-my-posh.psd1
@@ -64,6 +64,7 @@ FunctionsToExport = @('Write-ColorPreview',
                       'Test-Administrator',
                       'Get-ComputerName',
                       'Set-Newline',
+                      'Get-BatteryInfo',
                       'Get-ThemesLocation'
                       'Set-Prompt')
 


### PR DESCRIPTION
This pull request creates a new helper function to show current battery status. This is a development over my previous PR #292, and includes two enhancements: 
- Now works on both Windows and Linux 
- Replaced deprecated `Get-WmiObject` with `Get-CimInstance`  
- Returns nothing on non-battery operated devices (PC's) 
- Powerlevel9k theme start icon depends on OS now 

Refer to the linked PR for a full list of changes. The helper function can be used by calling and checking the `Get-BatteryInfo` function, as shown in the Powerlevel9k theme module here. 