### PR TITLE
Add Options.PreserveLastExitCode

### DIFF
--- a/defaults.ps1
+++ b/defaults.ps1
@@ -71,8 +71,9 @@ $global:ThemeSettings = New-Object -TypeName PSObject -Property @{
         VirtualEnvBackgroundColor               = [ConsoleColor]::Red
     }
     Options              = @{
-        ConsoleTitle  = $true
-        OriginSymbols = $false
+        ConsoleTitle         = $true
+        OriginSymbols        = $false
+        PreserveLastExitCode = $true
     }
 }
 

--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -40,7 +40,9 @@ function Set-Prompt {
         }
 
         $prompt
-        $global:LASTEXITCODE = $realLASTEXITCODE
+        if ($sl.Options.PreserveLastExitCode) {
+            $global:LASTEXITCODE = $realLASTEXITCODE
+        }
         Remove-Variable realLASTEXITCODE -Confirm:$false
     }
 


### PR DESCRIPTION
This adds to #289 by adding an option to disable the feature, in case a theme is already handling this in some way.

----

In my custom theme, I was already doing this, but with two additional features:

* The last exit code value is displayed in the prompt
* `$global:LASTEXITCODE` is cleared

Displaying the code is very helpful, but the trouble is if you run a powershell cmdlet, LASTEXITCODE doesn't get reset. This means the prompt will constantly show a non-zero exit code (displayed as a red error, in my prompt) until you run a successful executable command.

Unfortunately, clearing LASTEXITCODE is kind of non-standard behaviour so I'd guess it's not good to do this as part of oh-my-posh. 