### PR TITLE
Suppress python prompt from `virtualenv`

### DIFF
--- a/Helpers/Prompt.ps1
+++ b/Helpers/Prompt.ps1
@@ -176,6 +176,9 @@ function Test-VirtualEnv {
 }
 
 function Get-VirtualEnvName {
+    # Suppress prompt from virtualenv
+    $env:VIRTUAL_ENV_DISABLE_PROMPT="True"
+
     if ($env:VIRTUAL_ENV) {
         if ($PSVersionTable.Platform -eq 'Unix') {
             $virtualEnvName = ($env:VIRTUAL_ENV -split '/')[-1]


### PR DESCRIPTION
When using `virtualenv` package instead of the bundled `venv` for virtual environments in python, `virtualenv` appends the env
name to the prompt, like so,

![image](https://user-images.githubusercontent.com/26112391/101671355-67649c00-3a7a-11eb-9198-26577f3a65f5.png)


By setting env variable `VIRTUAL_ENV_DISABLE_PROMPT` to `True`, this behavior can be suppressed.

Fixes #326.